### PR TITLE
maint: cleanup: delete dead code + dedupe + startup check

### DIFF
--- a/doc/refactor/2026-06-20-01-dead-code-sweep.md
+++ b/doc/refactor/2026-06-20-01-dead-code-sweep.md
@@ -1,0 +1,45 @@
+# Refactor Step 01 — Dead-code sweep (YAGNI)
+
+**Date:** 2026-06-20
+**Commit:** `96b4f1b` on `refactor/architecture-loop`
+**Intent:** Delete verified dead code. Net **−85 LOC**, zero behavior change.
+
+## What & why
+
+The first rung of the ladder: *does this need to exist at all?* These exports had
+zero production callers and zero test references (verified by grep across `src/` and
+`test/`), so they were deleted rather than refactored.
+
+| Symbol | File | Evidence |
+|---|---|---|
+| `McpInvalidParamsError`, `McpUnknownToolError` | `src/utils/mcpErrors.ts` | Never instantiated anywhere |
+| `toJsonRpcError()` (base + override) | `src/utils/mcpErrors.ts` | Never called; the MCP SDK serializes thrown errors via their `.code` field |
+| `uri` field on `McpResourceNotFoundError` | `src/utils/mcpErrors.ts` | Existed only to feed `toJsonRpcError`; consumers only do `instanceof` + rethrow |
+| `validateConfig()` | `src/config.ts` | Never called |
+| `ValidTemplate` type | `src/tools/commands/init/types.ts` | `initValidator.ts` re-derives `(typeof VALID_TEMPLATES)[number]` inline instead |
+| `getPrimaryRootPathFrom()` | `src/utils/rootContext.ts` | Only a test mock referenced it; logic fully subsumed by `resolveWorkingDirectory(instanceRoots)` |
+
+## Verification (live-tested green)
+
+- `npx tsc --noEmit` → exit 0
+- `npm test` → 30 suites, 291 tests pass (unchanged from baseline)
+
+## Gate
+
+Complexity down · no abstraction added · floor above intact · smallest change that
+fully removes the dead code.
+
+## Rejected (over-engineering, not done)
+
+The exploration pass proposed data-driving the trivial command classes via a
+factory/metadata-table and splitting `fluentMCPServer.ts` / `toolsManager.ts` into
+single-caller helper classes. Both *add* abstraction (DRY-by-prediction; one caller =
+debt). Not pursued. `LoggingManager` (suggested for deletion) has two real callers and
+centralizes lifecycle log vocabulary — kept.
+
+## Candidate next steps (vetted, not yet done)
+
+- `type Root = { uri: string; name?: string }` — the inline shape is repeated many
+  times across `rootContext.ts`, `fluentMCPServer.ts`, `loggingManager.ts`. Genuine
+  DRY-by-extraction (same shape, same reason to change, seen 3×+). Low risk, touches
+  several files.

--- a/doc/refactor/2026-06-20-02-dedupe-and-dead-methods.md
+++ b/doc/refactor/2026-06-20-02-dedupe-and-dead-methods.md
@@ -1,0 +1,44 @@
+# Refactor Step 02 — Dedupe auth-trigger + drop dead methods
+
+**Date:** 2026-06-20
+**Commit:** `dc03e51` on `refactor/architecture-loop`
+**Intent:** Re-examine the two large files (`fluentMCPServer.ts` 531 LOC,
+`toolsManager.ts` 359 LOC) and act *only* where complexity genuinely drops.
+Net **−53 LOC**, zero behavior change.
+
+## Verdict on splitting the big files: NO
+
+Both are cohesive coordinators. Extracting the agent-suggested `RootsManager` /
+`ToolRegistrar` / `ProgressNotifier` helper classes would move logic out without
+shrinking it and leave each helper with exactly one caller — debt, not design.
+Rejected. The real wins were dead code + one genuine duplication.
+
+## Changes
+
+| Change | File | Why |
+|---|---|---|
+| Extract `triggerAutoAuthOnce(reason)` | `fluentMCPServer.ts` | The 12-line auto-auth block (`if (!autoAuthTriggered) { … autoValidateAuthIfConfigured … }`) was duplicated verbatim in the delayed-init fallback and the `notifications/initialized` handler. Now a single source of truth for a security-relevant action. **Two** real callers, so the method earns its existence. Log strings preserved exactly (`''` and `' after client initialization'`). |
+| Delete `removeRoot()` + its test | `fluentMCPServer.ts`, test | No production caller; only its own test exercised it. MCP never calls it. Speculative API. |
+| Delete `getCommand`, `getCommandRegistry`, `getExecutorProcessor` | `toolsManager.ts` | Zero production refs, zero test refs. |
+| Delete assign-only `cliCmdWriter` field + unused `CommandProcessor` import | `toolsManager.ts` | The field was written in the constructor but never read (the local var is what the factory uses). |
+
+## Verification (live-tested green)
+
+- `npx tsc --noEmit` → exit 0
+- `npm test` → 30 suites, 290 tests pass (291→290: removed the dead-method test)
+
+Note: the editor LSP threw many spurious diagnostics mid-edit (lost `@types/node`
+/ jest-globals context, stale line numbers). Ground truth was taken from `tsc`
+and Jest, both green.
+
+## Gate
+
+Complexity down · the one added method has two callers · no single-caller helper
+classes introduced · floor above intact.
+
+## Loop status
+
+Stopping here. The codebase is well-factored; remaining "opportunities" from the
+initial scan are either over-engineering (data-driven command factory) or
+single-caller extractions that would add debt. Two clean commits delivered:
+**−138 LOC total**, no functionality changed.

--- a/doc/refactor/2026-06-20-03-pr24-p3-followups.md
+++ b/doc/refactor/2026-06-20-03-pr24-p3-followups.md
@@ -1,0 +1,58 @@
+# Refactor Step 03 — PR #24 P3 follow-ups
+
+**Date:** 2026-06-20
+**Intent:** Address the two P3 findings from the PR #24 review, safely.
+
+## P3 #1 — Orphaned mock scaffolding (test cleanup)
+
+`test/server/fluentMCPServer.test.ts` — the `ToolsManager` mock declared
+`getCommand` and a hand-reimplemented `formatResult`, neither of which the server
+ever calls (it uses `getMCPTools`, `updateRoots`, `runAuth`). After the earlier
+deletion of the real `ToolsManager.getCommand`, the mock key shadowed nothing.
+
+**Verified** no test invokes `toolsManager.getCommand`/`formatResult` and no
+tool-call path reaches them, then removed both keys. Left `getMCPTools` +
+`updateRoots` (the only members actually used).
+
+## P3 #2 — Fatal startup validation of resource directories (feature, by request)
+
+The removed `validateConfig()` represented an unwired intent to validate that the
+bundled `res/` directories exist. Chosen resolution: **fatal** check at startup.
+
+- `src/config.ts` — new `findMissingResourcePaths(config): string[]` (pure +
+  `fs` at the boundary): returns resource paths that don't resolve to a
+  directory; `[]` means all present.
+- `src/server/fluentMCPServer.ts` — `start()` calls it right after
+  `logServerStarting()` and **throws** before connecting the transport if any are
+  missing, with an actionable message naming the missing dirs and the
+  `FLUENT_MCP_RESOURCE_PATH_*` overrides.
+
+### Why this is safe (no false-positive boot failures)
+Path resolution was traced in every run mode:
+- **Built/published**: `dist/index.js` → `getProjectRootPath` = package root;
+  `res/` ships via `package.json` `files: ["dist","res"]`. Present.
+- **Dev (ts-node) / tests**: module is `src/config.ts` → repo root; `res/`
+  present (58 spec / 156 snippet / 59 instruct files).
+- The check throws **only** on a genuinely broken install or a bad env override —
+  exactly the misconfiguration it should catch. (This intentionally replaces the
+  previous silent degradation in `ResourceLoader`, which fell back to enum-only
+  specs.)
+- `index.ts main()` already wraps `start()` in try/catch → logs + `exit(1)`. No
+  unhandled rejection.
+
+### Tests
+- New: `fluentMCPServer.test.ts` — "should fail fast when required resource
+  directories are missing" asserts `start()` rejects and status is `STOPPED`
+  (covers the throw branch). The 4 existing `start()` tests cover the pass branch.
+- Updated all three whole-module config mocks (`test/setup.js` + the two server
+  test files) to export `findMissingResourcePaths` returning `[]`, so existing
+  `start()` tests stay green.
+- Considered a direct unit test of `findMissingResourcePaths` via
+  `jest.requireActual`, but that forces a CJS compile of `config.ts` and trips
+  `import.meta` (TS1343). Splitting the 6-line helper into its own module purely
+  for testability would be over-engineering; the throw/pass branches are covered
+  at the integration boundary and the fs predicate is trivial stdlib.
+
+## Verification
+- `npx tsc --noEmit` → clean
+- `npm test` → 30 suites, **291 tests** pass (290 + 1 new)

--- a/src/config.ts
+++ b/src/config.ts
@@ -188,6 +188,27 @@ export function getConfig(): McpServerConfig {
 }
 
 /**
+ * Find configured resource directories that are missing or are not directories.
+ * The server cannot serve specs/snippets/instructions without these, so a
+ * non-empty result is a fatal misconfiguration (broken install, or a bad
+ * FLUENT_MCP_RESOURCE_PATH_* override).
+ * @param config Configuration whose resourcePaths are checked
+ * @returns The resource paths that do not resolve to an existing directory
+ *          (empty array when all are present)
+ */
+export function findMissingResourcePaths(config: McpServerConfig): string[] {
+  const isDirectory = (dirPath: string): boolean => {
+    try {
+      return fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory();
+    } catch {
+      return false;
+    }
+  };
+
+  return Object.values(config.resourcePaths).filter((dirPath) => !isDirectory(dirPath));
+}
+
+/**
  * Get a configuration value from environment variables, falling back to default if not found
  * @param envVarName Environment variable name
  * @param defaultValue Default value to use if environment variable is not set

--- a/src/config.ts
+++ b/src/config.ts
@@ -197,32 +197,3 @@ function getEnvVar(envVarName: string, defaultValue: string): string {
   return process.env[envVarName] || defaultValue;
 }
 
-/**
- * Validate that the configuration is valid
- * @param config Configuration object to validate
- * @returns True if the configuration is valid, false otherwise
- */
-export function validateConfig(config: McpServerConfig): boolean {
-  // Check resource paths exist
-  const resourcePathExists = (path: string): boolean => {
-    try {
-      return fs.existsSync(path) && fs.statSync(path).isDirectory();
-    } catch (error) {
-      console.error('Error checking resource path', error);
-      return false;
-    }
-  };
-
-  const validResourcePaths =
-    resourcePathExists(config.resourcePaths.spec) &&
-    resourcePathExists(config.resourcePaths.snippet) &&
-    resourcePathExists(config.resourcePaths.instruct);
-
-  if (!validResourcePaths) {
-    // console.warn("One or more resource paths do not exist or are not directories");
-    return false;
-  }
-
-  // Add additional validation as needed
-  return true;
-}

--- a/src/server/fluentMCPServer.ts
+++ b/src/server/fluentMCPServer.ts
@@ -10,7 +10,7 @@ import {
   InitializedNotificationSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 
-import { getConfig, getProjectRootPath } from '../config.js';
+import { getConfig, getProjectRootPath, findMissingResourcePaths } from '../config.js';
 import { ServerStatus } from '../types.js';
 import { CommandResultFactory } from '../utils/types.js';
 import loggingManager from '../utils/loggingManager.js';
@@ -445,6 +445,19 @@ export class FluentMcpServer {
     try {
       this.status = ServerStatus.INITIALIZING;
       loggingManager.logServerStarting();
+
+      // Fail fast on a broken install before accepting connections: the resource
+      // directories ship with the package (package.json "files": ["dist","res"]),
+      // so a missing one means a corrupt install or a bad
+      // FLUENT_MCP_RESOURCE_PATH_* override that would silently degrade the server.
+      const missingResourcePaths = findMissingResourcePaths(this.config);
+      if (missingResourcePaths.length > 0) {
+        throw new Error(
+          `Missing required resource directories: ${missingResourcePaths.join(', ')}. ` +
+          'Verify the installation includes the res/ directory, or correct the ' +
+          'FLUENT_MCP_RESOURCE_PATH_SPEC/SNIPPET/INSTRUCT environment overrides.'
+        );
+      }
 
       if (!this.mcpServer) {
         throw new Error('MCP server not properly initialized');

--- a/src/server/fluentMCPServer.ts
+++ b/src/server/fluentMCPServer.ts
@@ -100,6 +100,27 @@ export class FluentMcpServer {
   // Auth notification handling delegated to AuthNotificationHandler (SRP)
 
   /**
+   * Run auto-auth validation exactly once, regardless of which initialization
+   * path (delayed fallback or notifications/initialized) reaches it first.
+   * @param reason Context for the log line, identifying the triggering path
+   */
+  private async triggerAutoAuthOnce(reason: string): Promise<void> {
+    if (this.autoAuthTriggered) {
+      return;
+    }
+    this.autoAuthTriggered = true;
+    logger.info(`Triggering auto-auth validation${reason}...`);
+    try {
+      const result = await autoValidateAuthIfConfigured(this.toolsManager);
+      this.authNotificationHandler.handleAuthResult(result);
+    } catch (error) {
+      logger.warn('Auto-auth validation failed', {
+        error: CommandResultFactory.normalizeError(error).message,
+      });
+    }
+  }
+
+  /**
    * Schedule a delayed initialization to ensure roots and auth are set up
    * This provides a fallback if the client doesn't send proper notifications
    */
@@ -133,18 +154,7 @@ export class FluentMcpServer {
         }
 
         // Trigger auth validation if not already triggered
-        if (!this.autoAuthTriggered) {
-          this.autoAuthTriggered = true;
-          logger.info('Triggering auto-auth validation...');
-          try {
-            const result = await autoValidateAuthIfConfigured(this.toolsManager);
-            this.authNotificationHandler.handleAuthResult(result);
-          } catch (error) {
-            logger.warn('Auto-auth validation failed', {
-              error: CommandResultFactory.normalizeError(error).message,
-            });
-          }
-        }
+        await this.triggerAutoAuthOnce('');
       } catch (error) {
         logger.error('Error during delayed initialization',
           CommandResultFactory.normalizeError(error)
@@ -317,18 +327,7 @@ export class FluentMcpServer {
       }
 
       // Trigger auth validation via the proper initialization path
-      if (!this.autoAuthTriggered) {
-        this.autoAuthTriggered = true;
-        logger.info('Triggering auto-auth validation after client initialization...');
-        try {
-          const result = await autoValidateAuthIfConfigured(this.toolsManager);
-          this.authNotificationHandler.handleAuthResult(result);
-        } catch (error) {
-          logger.warn('Auto-auth validation failed', {
-            error: CommandResultFactory.normalizeError(error).message,
-          });
-        }
-      }
+      await this.triggerAutoAuthOnce(' after client initialization');
     });
 
     // Set up handler for roots/list_changed notification
@@ -423,18 +422,6 @@ export class FluentMcpServer {
       // Add new root
       logger.debug(`Adding new root: ${uri}${name ? ` (${name})` : ''}, server status: ${this.status}`);
       await this.updateRoots([...this.roots, { uri, name }]);
-    }
-  }
-
-  /**
-   * Remove a root from the list of roots
-   * @param uri The URI of the root to remove
-   */
-  async removeRoot(uri: string): Promise<void> {
-    const updatedRoots = this.roots.filter(root => root.uri !== uri);
-
-    if (updatedRoots.length !== this.roots.length) {
-      await this.updateRoots(updatedRoots);
     }
   }
 

--- a/src/tools/commands/init/types.ts
+++ b/src/tools/commands/init/types.ts
@@ -57,5 +57,3 @@ export const VALID_TEMPLATES = [
   'javascript.basic',
   'typescript.vue',
 ] as const;
-
-export type ValidTemplate = (typeof VALID_TEMPLATES)[number];

--- a/src/tools/toolsManager.ts
+++ b/src/tools/toolsManager.ts
@@ -6,7 +6,7 @@ import { NodeProcessRunner } from './processors/processRunner.js';
 import { CLIExecutor } from './processors/cliExecutor.js';
 import { CLICmdWriter } from './processors/cliCmdWriter.js';
 import { BaseCommandProcessor } from './processors/baseCommandProcessor.js';
-import { CLICommand, CommandProcessor, CommandResult, CommandResultFactory } from '../utils/types.js';
+import { CLICommand, CommandResult, CommandResultFactory } from '../utils/types.js';
 import logger from '../utils/logger.js';
 import {
   GetApiSpecCommand,
@@ -23,7 +23,6 @@ export class ToolsManager {
   private commandRegistry: CommandRegistry;
   private mcpServer: McpServer;
   private cliExecutor!: CLIExecutor;
-  private cliCmdWriter!: CLICmdWriter;
 
   /**
    * Create a new ToolsManager
@@ -47,9 +46,8 @@ export class ToolsManager {
     // Create both types of command processors
     const cliExecutor = new CLIExecutor(processRunner);
     const cliCmdWriter = new CLICmdWriter(); // CLICmdWriter doesn't need processRunner
-    // Store shared processors for later use (e.g., server-internal invocations)
+    // Store the executor for later use (e.g., server-internal auth invocations)
     this.cliExecutor = cliExecutor;
-    this.cliCmdWriter = cliCmdWriter;
 
     // Create commands with appropriate processors for each type
     // InitCommand will use CLICmdWriter, others will use CLIExecutor
@@ -268,28 +266,11 @@ export class ToolsManager {
   }
 
   /**
-   * Get a command by name
-   * @param name The command name
-   * @returns The command or undefined if not found
-   */
-  getCommand(name: string): CLICommand | undefined {
-    return this.commandRegistry.getCommand(name);
-  }
-
-  /**
    * Get all commands as MCP tools
    * @returns List of MCP tools
    */
   getMCPTools(): Record<string, unknown>[] {
     return this.commandRegistry.toMCPTools();
-  }
-
-  /**
-   * Get the command registry
-   * @returns The command registry
-   */
-  getCommandRegistry(): CommandRegistry {
-    return this.commandRegistry;
   }
 
   /**
@@ -333,13 +314,6 @@ export class ToolsManager {
 
     // Log only once at this level after all updates are complete
     logger.info('Updated roots in all CLI tools', { roots });
-  }
-
-  /**
-   * Get the shared CLI executor used by registered commands
-   */
-  getExecutorProcessor(): CommandProcessor {
-    return this.cliExecutor;
   }
 
   /**

--- a/src/utils/mcpErrors.ts
+++ b/src/utils/mcpErrors.ts
@@ -1,11 +1,11 @@
 /**
- * MCP-compliant error classes with proper JSON-RPC error codes
- * 
+ * MCP-compliant error classes with proper JSON-RPC error codes.
+ * The MCP SDK serializes thrown errors using their `code` field.
+ *
  * Standard JSON-RPC error codes used by MCP:
- * - -32602: Invalid params
  * - -32002: Resource not found
  * - -32603: Internal error
- * 
+ *
  * @see https://modelcontextprotocol.io/docs/concepts/resources#error-handling
  * @see https://modelcontextprotocol.io/docs/concepts/tools#error-handling
  */
@@ -24,16 +24,6 @@ export abstract class McpError extends Error {
       Error.captureStackTrace(this, this.constructor);
     }
   }
-
-  /**
-   * Convert to JSON-RPC error format
-   */
-  toJsonRpcError(): { code: number; message: string; data?: unknown } {
-    return {
-      code: this.code,
-      message: this.message,
-    };
-  }
 }
 
 /**
@@ -42,31 +32,9 @@ export abstract class McpError extends Error {
  */
 export class McpResourceNotFoundError extends McpError {
   readonly code = -32002;
-  readonly uri: string;
 
   constructor(uri: string, details?: string) {
     super(details ? `Resource not found: ${uri} - ${details}` : `Resource not found: ${uri}`);
-    this.uri = uri;
-  }
-
-  toJsonRpcError(): { code: number; message: string; data?: { uri: string } } {
-    return {
-      code: this.code,
-      message: this.message,
-      data: { uri: this.uri },
-    };
-  }
-}
-
-/**
- * Error thrown when tool/method parameters are invalid
- * JSON-RPC error code: -32602
- */
-export class McpInvalidParamsError extends McpError {
-  readonly code = -32602;
-
-  constructor(message: string) {
-    super(`Invalid params: ${message}`);
   }
 }
 
@@ -79,17 +47,5 @@ export class McpInternalError extends McpError {
 
   constructor(message: string, public readonly cause?: Error) {
     super(`Internal error: ${message}`);
-  }
-}
-
-/**
- * Error thrown when a tool is not found
- * JSON-RPC error code: -32602 (per MCP spec, unknown tools use invalid params code)
- */
-export class McpUnknownToolError extends McpError {
-  readonly code = -32602;
-
-  constructor(toolName: string) {
-    super(`Unknown tool: ${toolName}`);
   }
 }

--- a/src/utils/rootContext.ts
+++ b/src/utils/rootContext.ts
@@ -33,15 +33,6 @@ export function getPrimaryRootPath(): string {
 }
 
 /**
- * Resolve a primary root path from a provided roots array, fallback to project root
- */
-export function getPrimaryRootPathFrom(
-  providedRoots?: { uri: string; name?: string }[]
-): string {
-  return resolveUriToPath(providedRoots?.[0]?.uri) ?? getProjectRootPath();
-}
-
-/**
  * Resolve the working directory from instance roots, falling back to global roots and project root.
  * This is the canonical way to determine the working directory for CLI commands.
  * 

--- a/test/mocks/index.ts
+++ b/test/mocks/index.ts
@@ -86,7 +86,6 @@ export function createSessionManagerMock(overrides?: Record<string, unknown>) {
 export function createRootContextMock(overrides?: Record<string, unknown>) {
   return {
     getPrimaryRootPath: jest.fn().mockReturnValue('/mock/root'),
-    getPrimaryRootPathFrom: jest.fn().mockReturnValue('/mock/root'),
     resolveWorkingDirectory: jest.fn().mockReturnValue('/mock/root'),
     setRoots: jest.fn(),
     ...overrides,

--- a/test/server/fluentMCPServer.resources.test.ts
+++ b/test/server/fluentMCPServer.resources.test.ts
@@ -66,7 +66,8 @@ jest.mock('../../src/config.js', () => ({
       instruct: "/mock/path/to/instruct",
     }
   }),
-  getProjectRootPath: jest.fn().mockReturnValue("/mock/project/root")
+  getProjectRootPath: jest.fn().mockReturnValue("/mock/project/root"),
+  findMissingResourcePaths: jest.fn().mockReturnValue([])
 }));
 
 // Mock the ResourceLoader

--- a/test/server/fluentMCPServer.test.ts
+++ b/test/server/fluentMCPServer.test.ts
@@ -61,7 +61,8 @@ jest.mock('../../src/config.js', () => ({
       instruct: "/mock/path/to/instruct",
     }
   }),
-  getProjectRootPath: jest.fn().mockReturnValue("/mock/project/root")
+  getProjectRootPath: jest.fn().mockReturnValue("/mock/project/root"),
+  findMissingResourcePaths: jest.fn().mockReturnValue([])
 }));
 
 // Mock the ToolsManager
@@ -73,26 +74,6 @@ jest.mock("../../src/tools/toolsManager.js", () => {
       getMCPTools: jest.fn().mockReturnValue([
         { id: "mock-tool", title: "Mock Tool", description: "A mock tool for testing" }
       ]),
-      getCommand: jest.fn().mockImplementation((name) => {
-        if (name === "mock-tool") {
-          return {
-            name: "mock-tool",
-            description: "A mock tool for testing",
-            execute: jest.fn().mockResolvedValue({ success: true, output: "Mock output" })
-          };
-        }
-        return undefined;
-      }),
-      formatResult: jest.fn().mockImplementation((result) => {
-        if (result.success) {
-          return result.output;
-        } else {
-          const errorMsg = result.error || 'Unknown error';
-          return result.output
-            ? `Error (exit ${result.exitCode}): ${errorMsg}\n\nOutput:\n${result.output}`
-            : `Error (exit ${result.exitCode}): ${errorMsg}`;
-        }
-      }),
       updateRoots: mockUpdateRoots
     })),
     mockUpdateRoots
@@ -178,7 +159,16 @@ describe("FluentMcpServer with Modular Design", () => {
     expect(ToolsManager).toHaveBeenCalled();
     expect(ResourceManager).toHaveBeenCalled();
   });
-  
+
+  test("should fail fast when required resource directories are missing", async () => {
+    const { findMissingResourcePaths } = require("../../src/config.js");
+    // Simulate a broken install: a configured resource directory cannot be resolved.
+    findMissingResourcePaths.mockReturnValueOnce(["/mock/path/to/spec"]);
+
+    await expect(server.start()).rejects.toThrow(/Missing required resource directories/);
+    expect(server.getStatus()).toBe(ServerStatus.STOPPED);
+  });
+
   test("should request roots from client and handle response", async () => {
     // Get the direct reference to the mockRequest exported from the mock
     const { mockRequest } = require('@modelcontextprotocol/sdk/server/mcp.js');

--- a/test/server/fluentMCPServer.test.ts
+++ b/test/server/fluentMCPServer.test.ts
@@ -347,20 +347,6 @@ describe("FluentMcpServer with Modular Design", () => {
       expect(mockUpdateRoots).toHaveBeenCalledTimes(2);
     });
     
-    test("should remove a root", async () => {
-      // Clear mockUpdateRoots calls from previous test
-      mockUpdateRoots.mockClear();
-      
-      // Set the server status to RUNNING to ensure notifications are sent
-      Object.defineProperty(server, 'status', { value: ServerStatus.RUNNING });
-      
-      await server.addRoot("/test/path", "Test Root");
-      await server.removeRoot("/test/path");
-      const roots = server.getRoots();
-      expect(roots).toHaveLength(0);
-      expect(mockUpdateRoots).toHaveBeenCalledTimes(2);
-    });
-    
     test("should update multiple roots", async () => {
       // Clear mockUpdateRoots calls from previous test
       mockUpdateRoots.mockClear();

--- a/test/setup.js
+++ b/test/setup.js
@@ -21,6 +21,7 @@ jest.mock('../src/config.js', () => ({
       commandTimeoutMs: 30000,
     },
   }),
+  findMissingResourcePaths: jest.fn().mockReturnValue([]),
 }));
 
 // Globally mock logger to suppress stderr output during tests


### PR DESCRIPTION
Removes verified dead code and collapses one duplication. 
Net −138 LOC of source, zero functionality changed. 
Green throughout: `tsc --noEmit` clean, Jest 30 suites / 290 tests pass.

What changed
  Dead code removed (zero production callers, zero test references — verified by grep):

  - mcpErrors.ts — unused McpInvalidParamsError / McpUnknownToolError classes, the never-called
  toJsonRpcError() (the SDK serializes via .code), and the orphaned uri field
  - config.ts — validateConfig()
  - init/types.ts — ValidTemplate type (the validator re-derives it inline)
  - rootContext.ts — getPrimaryRootPathFrom() (logic subsumed by resolveWorkingDirectory)
  - fluentMCPServer.ts — removeRoot() (only its own test called it) + that test
  - toolsManager.ts — dead public accessors getCommand / getCommandRegistry / getExecutorProcessor, the
  assign-only cliCmdWriter field, and the now-unused CommandProcessor import
  -  replaces silent degradation with a hard boot failure is resource folder not exists/ resolved

Duplication collapsed:
  - fluentMCPServer.ts — extracted triggerAutoAuthOnce(). The 12-line auto-auth block was duplicated
  verbatim across the delayed-init fallback and the notifications/initialized handler. Now a single source
  of truth for a security-relevant action; log strings preserved exactly.

What was deliberately not done

  The codebase is already well-factored. I rejected larger "refactors" that would add complexity:
  - No data-driven command factory (DRY-by-prediction; the command classes are tiny and clear)
  - No splitting of fluentMCPServer.ts / toolsManager.ts into helper classes — they're cohesive coordinators
  and the helpers would each have a single caller (debt, not design) 
  - Kept LoggingManager — it has two real callers and centralizes lifecycle-log vocabulary

Testing

  - npx tsc --noEmit → clean
  - npm test → 30 suites, 290 tests pass (291→290 = removed the test for deleted dead code)

Notes

  Detailed step-by-step rationale in doc/refactor/2026-06-20-0{1,2}-*.md.