### PR TITLE
feat: upgrade to sdk@4.9.0 with new types and verified all resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 An [MCP server](https://modelcontextprotocol.io) that brings [ServiceNow Fluent SDK](https://www.servicenow.com/docs/bundle/yokohama-application-development/page/build/servicenow-sdk/concept/servicenow-fluent.html) capabilities to AI-assisted development environments. Enables natural language interaction with ServiceNow SDK commands, API specifications, code snippets, and development resources.
 
-Built for **`@servicenow/sdk` 4.8.1**.
+Built for **`@servicenow/sdk` 4.9.0**.
 
 ## Key Features
 
 - **Complete SDK Coverage** - ServiceNow SDK commands: `init`, `build`, `install`, `dependencies`, `transform`, `download`, `clean`, `pack`, `explain`, `query`
-- **Rich Resources** - API specifications, instructions, and code snippets for **64 ServiceNow metadata types**
+- **Rich Resources** - API specifications, instructions, and code snippets for **65 ServiceNow metadata types**
 - **API Documentation Lookup** - `explain_fluent_api` returns SDK docs for any Fluent API or guide — no project required
 - **Auto-Authentication** - Automatic auth profile detection and session management via environment variables
 - **Session-Aware** - Maintains working directory and auth context across commands
@@ -101,7 +101,7 @@ Standardized URI patterns following MCP specification:
 
 ### Supported Metadata Types
 
-64 metadata types across the following categories:
+65 metadata types across the following categories:
 
 **Core Types:** `acl`, `application-menu`, `business-rule`, `client-script`, `cross-scope-privilege`, `data-policy`, `form`, `import-set`, `instance-scan`, `list`, `property`, `role`, `scheduled-script`, `script-action`, `script-include`, `scripted-rest`, `sla`, `table`, `ui-action`, `ui-page`, `ui-policy`, `user-preference`
 
@@ -121,9 +121,22 @@ Standardized URI patterns following MCP specification:
 
 **Workspace & Analytics:** `workspace`, `dashboard`
 
-**ATF (Automated Test Framework):** `atf-appnav`, `atf-catalog-action`, `atf-catalog-validation`, `atf-catalog-variable`, `atf-email`, `atf-form`, `atf-form-action`, `atf-form-declarative-action`, `atf-form-field`, `atf-form-sp`, `atf-reporting`, `atf-rest-api`, `atf-rest-assert-payload`, `atf-server`, `atf-server-catalog-item`, `atf-server-record`
+**ATF (Automated Test Framework):** `atf-appnav`, `atf-catalog-action`, `atf-catalog-validation`, `atf-catalog-variable`, `atf-email`, `atf-form`, `atf-form-action`, `atf-form-declarative-action`, `atf-form-field`, `atf-form-sp`, `atf-reporting`, `atf-rest-api`, `atf-rest-assert-payload`, `atf-server`, `atf-server-catalog-item`, `atf-server-record`, `atf-ui-test-script`
 
-### What's new in 4.8.x
+### What's new in 4.9.0
+
+This release of the MCP server tracks `@servicenow/sdk` 4.9.0 — a maintenance and bug-fix release (Flow, ClientScript, ImportSet, SLA transform/build reliability) with select authoring-surface additions:
+
+- **New metadata type**: `atf-ui-test-script` — the `atf.uiTestScript.runTest()` ATF step runs a TestingLibrary test body in the client test runner to test custom UI components (Angular/React widgets, embedded SPAs, custom workspaces, `now-*` web components) that the standard `atf.form.*` / `atf.catalog.*` steps cannot reach.
+- **Multi-language choice labels** — a choice field's `choices` value may be an array of `ChoiceConfig` objects, each with a `language` (BCP 47) key, producing one translated `sys_choice` record per language.
+- **`protectionPolicy` on AI Agent & AI Agentic Workflow** — `AiAgent` and `AiAgenticWorkflow` accept `protectionPolicy: 'read' | 'protected'` for post-install access control.
+- **`Role.federatedId`** — optional identifier to match a role to an externally federated role during identity federation.
+- **Table index platform columns** — a table `index` entry's `element` may reference platform default columns (for example, `sys_created_on`).
+- **Now Assist Skill Kit providers** — new LLM providers selectable by name: `Now LLM LTS Generic`, `Google Cloud Vertex AI`, `Amazon Bedrock`.
+
+> Source-of-truth note: two release-note claims are not corroborated by the installed package and were treated as corrections — Form `table_field.field` is documented as a schema column name (not loosened to "any string"), and the four named NASK model strings appear nowhere in the package (`model` is a free string). See `.mosey/upgrade-sdk-4.9.0.md`.
+
+### Previously (4.8.x)
 
 This release of the MCP server tracks `@servicenow/sdk` 4.8.0 and adds support for the following Fluent APIs and SDK enhancements:
 
@@ -138,7 +151,7 @@ This release of the MCP server tracks `@servicenow/sdk` 4.8.0 and adds support f
 
 ### Previously (4.7.x)
 
-This release of the MCP server tracks `@servicenow/sdk` 4.8.0 and adds support for the following Fluent APIs and SDK enhancements:
+This release of the MCP server tracked `@servicenow/sdk` 4.7.x and added support for the following Fluent APIs and SDK enhancements:
 
 - **New metadata type**: `data-policy` — the `DataPolicy` API (`sys_data_policy2`) for server-side mandatory/read-only field enforcement that cannot be bypassed via API, import, or web service.
 - **Flow error handling & parallelism** — `wfa.flowLogic.tryCatch`, `wfa.flowLogic.doInParallel`, and `wfa.flowLogic.appendToFlowVariables` (append to `Array.Object` flow variables).
@@ -157,7 +170,7 @@ Added `custom-action`, `inbound-email-action`, `sp-header-footer`, and `sp-page-
 
 ## Configuration
 
-**Requirements:** Node.js 20.18.0+, npm 11.4.1+, `@servicenow/sdk` 4.8.1
+**Requirements:** Node.js 20.18.0+, npm 11.4.1+, `@servicenow/sdk` 4.9.0
 
 ### MCP Client Setup
 
@@ -291,7 +304,7 @@ npm run build && npm run inspect
 3. **Test Version:**
    - Set `flag` parameter to `-v`
    - Click **Execute**
-   - Verify response shows the SDK version (e.g., `4.8.1`)
+   - Verify response shows the SDK version (e.g., `4.9.0`)
 4. **Test Help:**
    - Set `flag` parameter to `-h`
    - Set `command` parameter to `build`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@modesty/fluent-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modesty/fluent-mcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@servicenow/sdk": "4.8.1",
+        "@servicenow/sdk": "4.9.0",
         "zod": "^4.4.3",
         "zod-to-json-schema": "^3.25.2"
       },
@@ -788,9 +788,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.14.0",
@@ -799,7 +799,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
@@ -839,9 +839,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1054,9 +1054,9 @@
       }
     },
     "node_modules/@fastify/fast-json-stringify-compiler/node_modules/fast-json-stringify": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.0.tgz",
-      "integrity": "sha512-YV53BAbR3Qwq37wfD1oZ97YJ0nYj6CwfzKXQ38ock9XxI2EnLOdl5psKms6Evook6ACckytZJOaKY0ThmIi1uw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
+      "integrity": "sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==",
       "funding": [
         {
           "type": "github",
@@ -1072,10 +1072,26 @@
         "@fastify/merge-json-schemas": "^0.2.0",
         "ajv": "^8.12.0",
         "ajv-formats": "^3.0.1",
-        "fast-uri": "^3.0.0",
+        "fast-uri": "^4.0.0",
         "json-schema-ref-resolver": "^3.0.0",
         "rfdc": "^1.2.0"
       }
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler/node_modules/fast-uri": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.0.tgz",
+      "integrity": "sha512-ZodJ2cRiLVWGi9IgPb3mbgSqM4CD3LexCHkuv0FfBXHJI1ADfucTD06m6clO2Cy5RZYsw/SiCVl/dyrFI/SYWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/@fastify/forwarded": {
       "version": "3.0.1",
@@ -1164,9 +1180,9 @@
       }
     },
     "node_modules/@fastify/reply-from": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@fastify/reply-from/-/reply-from-12.6.2.tgz",
-      "integrity": "sha512-FhMvsRJa4HMG0q0/Yi06sgwVFd/Wc8E/+RbHsqB0Q+883C66RPrS6qwZKBPje2mVzsyEb9sjq7wlyvi35zRW0A==",
+      "version": "12.6.3",
+      "resolved": "https://registry.npmjs.org/@fastify/reply-from/-/reply-from-12.6.3.tgz",
+      "integrity": "sha512-oP8V1jo1SVL2MtagitoOGK7voP88VID0sGsm2Ob1lEzD0h9GBWq36zAe8JmYjllj0ybdHcMTQEhE/EQzVAjWsQ==",
       "funding": [
         {
           "type": "github",
@@ -1183,10 +1199,26 @@
         "end-of-stream": "^1.4.4",
         "fast-content-type-parse": "^3.0.0",
         "fast-querystring": "^1.1.2",
-        "fastify-plugin": "^5.0.1",
+        "fastify-plugin": "^6.0.0",
         "toad-cache": "^3.7.0",
         "undici": "^7.0.0"
       }
+    },
+    "node_modules/@fastify/reply-from/node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@fastify/send": {
       "version": "4.1.0",
@@ -1253,9 +1285,9 @@
       }
     },
     "node_modules/@fastify/static/node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -3584,35 +3616,35 @@
       }
     },
     "node_modules/@servicenow/isomorphic-rollup": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@servicenow/isomorphic-rollup/-/isomorphic-rollup-1.3.6.tgz",
-      "integrity": "sha512-dJ405mgJAAr9FGDILvOHy2BQXEUNjPxntda8wN8Ie7+0PDLfF4y236h63qih6Exz1h7yy9Dn/kUoP2vNekeM3A==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@servicenow/isomorphic-rollup/-/isomorphic-rollup-1.3.7.tgz",
+      "integrity": "sha512-XYYXmoiELruLqk1e922vNnsg6LP0WelERxyflPpBCymzQq2c5fYmPCTonr6DOQXpdQsFJ5PEb808b4DhCwYGpg==",
       "license": "MIT",
       "dependencies": {
         "@fastify/http-proxy": "11.4.4",
         "@fastify/static": "9.1.3",
-        "@swc/core": "1.15.11",
+        "@swc/core": "1.15.43",
         "fastify": "5.8.5",
         "fastify-plugin": "5.1.0",
         "femtocolor": "2.0.3",
         "get-port": "5.1.1",
         "joi": "17.13.4",
         "ms": "2.1.3",
-        "sass": "1.86.3"
+        "sass": "1.101.0"
       },
       "optionalDependencies": {
         "rollup-plugin-livereload": "2.0.5"
       }
     },
     "node_modules/@servicenow/sdk": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@servicenow/sdk/-/sdk-4.8.1.tgz",
-      "integrity": "sha512-fSZZhy1wP6z5LtUGXqoW9f8C9sZA5i8HBLcMl0Pa2X/M80VAxaH/7o04MmWGxGxYoJ9Z6Kl5ecM8weTt+WlvUg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@servicenow/sdk/-/sdk-4.9.0.tgz",
+      "integrity": "sha512-LKsf3NwSv5RUppB2nsNRMqObnuIuh3lyUeHCUGMR/N7BjTgZM+bd3uyT0rwKpz/78eDkj6DN/gzGZMYe4/3ttQ==",
       "license": "MIT",
       "dependencies": {
-        "@servicenow/sdk-api": "4.8.1",
-        "@servicenow/sdk-cli": "4.8.1",
-        "@servicenow/sdk-core": "4.8.1"
+        "@servicenow/sdk-api": "4.9.0",
+        "@servicenow/sdk-cli": "4.9.0",
+        "@servicenow/sdk-core": "4.9.0"
       },
       "bin": {
         "now-sdk": "bin/index.js",
@@ -3626,24 +3658,37 @@
       }
     },
     "node_modules/@servicenow/sdk-api": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@servicenow/sdk-api/-/sdk-api-4.8.1.tgz",
-      "integrity": "sha512-lquX8uDNSWgQHfM4Pm3IW7wZeWOJ1Fkz2scLGh3E8Z36lQn0l+oUYlb+lDAqgjGFpvD/IFhAbEZeVCkBtW6aKw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@servicenow/sdk-api/-/sdk-api-4.9.0.tgz",
+      "integrity": "sha512-A0FONaPmSMdD7U4BwjpZ4HOrrb6GTmZpDQ2Ppq7myCQJtnyEbFW+91oq4dfp+FvrlZe/neQxHSIBmACQMXBvLw==",
       "license": "MIT",
       "dependencies": {
-        "@servicenow/isomorphic-rollup": "1.3.6",
-        "@servicenow/sdk-build-core": "4.8.1",
-        "@servicenow/sdk-build-plugins": "4.8.1",
+        "@servicenow/isomorphic-rollup": "1.3.7",
+        "@servicenow/sdk-build-core": "4.9.0",
+        "@servicenow/sdk-build-plugins": "4.9.0",
         "crypto-js": "4.2.0",
         "fast-json-stable-stringify": "2.1.0",
         "fast-xml-parser": "5.7.2",
         "handlebars": "4.7.9",
         "lodash": "4.18.1",
+        "picomatch": "4.0.4",
         "zod": "3.23.8"
       },
       "engines": {
         "node": ">=20.18.0",
         "pnpm": ">=10.8.0"
+      }
+    },
+    "node_modules/@servicenow/sdk-api/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@servicenow/sdk-api/node_modules/zod": {
@@ -3656,18 +3701,19 @@
       }
     },
     "node_modules/@servicenow/sdk-build-core": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@servicenow/sdk-build-core/-/sdk-build-core-4.8.1.tgz",
-      "integrity": "sha512-CNQZl5H0pIbZQ9EKKFiEg1pd0J3V4LsAoGgUjaUsSdpnTVHsyZqnuL1IpWFWCUXwnEgZ+PxJZWR1mS59CRBAvg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@servicenow/sdk-build-core/-/sdk-build-core-4.9.0.tgz",
+      "integrity": "sha512-VpiBSljkO6IepvZHnmbvVjxJU6IE6FZIqaxU+FScPWwhV7Q8le2nowFnp8eeeLKBdaqoyGTTBvdSZ64ghgW2DQ==",
       "license": "MIT",
       "dependencies": {
-        "@servicenow/sdk-core": "4.8.1",
+        "@servicenow/sdk-core": "4.9.0",
         "ci-info": "4.4.0",
         "fast-glob": "3.3.3",
         "fflate": "0.8.2",
         "json5": "2.2.3",
         "jsonschema": "1.5.0",
         "lodash": "4.18.1",
+        "nanotar": "0.3.0",
         "pathe": "1.1.2",
         "prettier": "3.6.1",
         "readable-stream": "4.5.2",
@@ -3692,17 +3738,17 @@
       }
     },
     "node_modules/@servicenow/sdk-build-plugins": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@servicenow/sdk-build-plugins/-/sdk-build-plugins-4.8.1.tgz",
-      "integrity": "sha512-StFBvQgWaPnqfVymIYxFAanf8kLvp/gpkLLmUlWhc9qHthN/DPhB+QnAGpeMhvHvk1zKuztrtAj6CREJF9X6+A==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@servicenow/sdk-build-plugins/-/sdk-build-plugins-4.9.0.tgz",
+      "integrity": "sha512-D0O4I47PWv+FNvA1ndVUiPYPRgofmeWvvW4ZxTbILiXRQ8Kdt6BbUCcYJQIjK2IDFuEumiapFHT8vdGCclvnIg==",
       "license": "MIT",
       "dependencies": {
         "@cyclonedx/cyclonedx-library": "8.6.0",
         "@eslint-community/eslint-utils": "4.9.1",
         "@servicenow/glide": "27.0.5",
-        "@servicenow/sdk-build-core": "4.8.1",
-        "@servicenow/sdk-core": "4.8.1",
-        "@servicenow/sdk-repack": "4.8.1",
+        "@servicenow/sdk-build-core": "4.9.0",
+        "@servicenow/sdk-core": "4.9.0",
+        "@servicenow/sdk-repack": "4.9.0",
         "eslint": "9.39.4",
         "eslint-formatter-stylish": "8.40.0",
         "fast-xml-parser": "5.7.2",
@@ -3713,6 +3759,7 @@
         "md5.js": "1.3.5",
         "mime-types": "2.1.35",
         "packageurl-js": "2.0.1",
+        "picomatch": "4.0.4",
         "xml-js": "1.6.11",
         "xmlbuilder2": "4.0.3",
         "zod": "3.23.8"
@@ -3820,9 +3867,9 @@
       "license": "MIT"
     },
     "node_modules/@servicenow/sdk-build-plugins/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3960,6 +4007,18 @@
         "node": "*"
       }
     },
+    "node_modules/@servicenow/sdk-build-plugins/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@servicenow/sdk-build-plugins/node_modules/zod": {
       "version": "3.23.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
@@ -3970,20 +4029,21 @@
       }
     },
     "node_modules/@servicenow/sdk-cli": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@servicenow/sdk-cli/-/sdk-cli-4.8.1.tgz",
-      "integrity": "sha512-JBa8bTyjgWYr5UYhEfsMF7ce/+ey8DE/tIitWGUePVFVs8JN5SaFaHc3y0J+Jriv2b08BSxUmER8L2puLk5mgA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@servicenow/sdk-cli/-/sdk-cli-4.9.0.tgz",
+      "integrity": "sha512-Hiy7GVQp9OGXUfhbNChKndAo1hX6WlnFGUsM7pw4cbOySgOjAzxPqyPZHo2fw06GQypifNh6LX9CNvsXhiLgzg==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",
         "@napi-rs/keyring": "1.2.0",
-        "@servicenow/sdk-api": "4.8.1",
-        "@servicenow/sdk-build-core": "4.8.1",
+        "@servicenow/sdk-api": "4.9.0",
+        "@servicenow/sdk-build-core": "4.9.0",
         "chalk": "4.1.2",
         "clipboardy": "4.0.0",
         "lodash": "4.18.1",
         "open": "8.4.2",
         "openid-client": "5.6.5",
+        "rc": "1.2.8",
         "semver": "7.5.4",
         "tough-cookie": "5.1.2",
         "yargs": "17.6.2"
@@ -3994,9 +4054,9 @@
       }
     },
     "node_modules/@servicenow/sdk-core": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@servicenow/sdk-core/-/sdk-core-4.8.1.tgz",
-      "integrity": "sha512-pZjRdGmu8KcEFWK35JzEMF/zJ9wNqQ5vaLOmb+9yTkXOJl15YsUrUUBDiPzo7Vs0u7LNhvH1hIg4/CnQ89W8MQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@servicenow/sdk-core/-/sdk-core-4.9.0.tgz",
+      "integrity": "sha512-6ZJpD0MWe88xS44pybxAlEdkkB1bq2pGv6DQUnCfe5i2o/vOGKssBDdp1dnHRXkP2oT+OAfDpKkB/S6nZtEV7w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0",
@@ -4004,13 +4064,13 @@
       }
     },
     "node_modules/@servicenow/sdk-repack": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@servicenow/sdk-repack/-/sdk-repack-4.8.1.tgz",
-      "integrity": "sha512-5yN+Osw4e/U+dzHx/aBrr+GN/TXUgXQSDuKZsKHAhd1myvL9Fldo9O60fSFozGurHjR7IJUFzJNdUhqlHXtqFQ==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@servicenow/sdk-repack/-/sdk-repack-4.9.0.tgz",
+      "integrity": "sha512-glOrWcNzAwgJB5Rc0XPuWQP4MK2BgDvC4dSmMBbTE544Gi3kpnqW1WFfXEwVrHq7jD0o1lPwJCAL5kITiv0OZQ==",
       "license": "MIT",
       "dependencies": {
-        "@servicenow/isomorphic-rollup": "1.3.6",
-        "@servicenow/sdk-build-core": "4.8.1",
+        "@servicenow/isomorphic-rollup": "1.3.7",
+        "@servicenow/sdk-build-core": "4.9.0",
         "rollup": "4.60.0"
       }
     },
@@ -4471,14 +4531,14 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.15.11",
-      "resolved": "https://artifact.devsnc.com/repository/npm-all/@swc/core/-/core-1.15.11.tgz",
-      "integrity": "sha512-iLmLTodbYxU39HhMPaMUooPwO/zqJWvsqkrXv1ZI38rMb048p6N7qtAtTp37sw9NzSrvH6oli8EdDygo09IZ/w==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.43.tgz",
+      "integrity": "sha512-1CuKjFkPxIgGdeHVuNbkxmBxkcbdc08u0aiI43pFq6yY1tTVKmXT9hFEooyyKs/sJ3xf1GPHyEwTtk9Xl8dvQw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.25"
+        "@swc/types": "^0.1.27"
       },
       "engines": {
         "node": ">=10"
@@ -4488,16 +4548,18 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.15.11",
-        "@swc/core-darwin-x64": "1.15.11",
-        "@swc/core-linux-arm-gnueabihf": "1.15.11",
-        "@swc/core-linux-arm64-gnu": "1.15.11",
-        "@swc/core-linux-arm64-musl": "1.15.11",
-        "@swc/core-linux-x64-gnu": "1.15.11",
-        "@swc/core-linux-x64-musl": "1.15.11",
-        "@swc/core-win32-arm64-msvc": "1.15.11",
-        "@swc/core-win32-ia32-msvc": "1.15.11",
-        "@swc/core-win32-x64-msvc": "1.15.11"
+        "@swc/core-darwin-arm64": "1.15.43",
+        "@swc/core-darwin-x64": "1.15.43",
+        "@swc/core-linux-arm-gnueabihf": "1.15.43",
+        "@swc/core-linux-arm64-gnu": "1.15.43",
+        "@swc/core-linux-arm64-musl": "1.15.43",
+        "@swc/core-linux-ppc64-gnu": "1.15.43",
+        "@swc/core-linux-s390x-gnu": "1.15.43",
+        "@swc/core-linux-x64-gnu": "1.15.43",
+        "@swc/core-linux-x64-musl": "1.15.43",
+        "@swc/core-win32-arm64-msvc": "1.15.43",
+        "@swc/core-win32-ia32-msvc": "1.15.43",
+        "@swc/core-win32-x64-msvc": "1.15.43"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -4509,9 +4571,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.15.11",
-      "resolved": "https://artifact.devsnc.com/repository/npm-all/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.11.tgz",
-      "integrity": "sha512-QoIupRWVH8AF1TgxYyeA5nS18dtqMuxNwchjBIwJo3RdwLEFiJq6onOx9JAxHtuPwUkIVuU2Xbp+jCJ7Vzmgtg==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.43.tgz",
+      "integrity": "sha512-v1aVuvXdo/BHxJzco9V2xpHrvwWmhfS8t6gziY5wJxd+Z2h8AeJRnAwPD8itCDaGXVBwJ/CaKfxEzTkG0Va0OA==",
       "cpu": [
         "arm64"
       ],
@@ -4525,9 +4587,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.11",
-      "resolved": "https://artifact.devsnc.com/repository/npm-all/@swc/core-darwin-x64/-/core-darwin-x64-1.15.11.tgz",
-      "integrity": "sha512-S52Gu1QtPSfBYDiejlcfp9GlN+NjTZBRRNsz8PNwBgSE626/FUf2PcllVUix7jqkoMC+t0rS8t+2/aSWlMuQtA==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.43.tgz",
+      "integrity": "sha512-lp3d4Lamc8dt5huYdGLSR+9hLxmfr1jb0l+4XXG2zPqZwYWRN9R0U2qYoTrggiU2RWW0oV9VbWM3kBnqIc2kdQ==",
       "cpu": [
         "x64"
       ],
@@ -4541,9 +4603,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.11",
-      "resolved": "https://artifact.devsnc.com/repository/npm-all/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.11.tgz",
-      "integrity": "sha512-lXJs8oXo6Z4yCpimpQ8vPeCjkgoHu5NoMvmJZ8qxDyU99KVdg6KwU9H79vzrmB+HfH+dCZ7JGMqMF//f8Cfvdg==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.43.tgz",
+      "integrity": "sha512-JWTQQELtsG5GgphDrr/XqqmM2pDN3cZqbMS0Mrg+iTiXL3F74sn/S2IyYE/5u4h2KLkTf9qQ7dXyxsbx7YzkeA==",
       "cpu": [
         "arm"
       ],
@@ -4557,9 +4619,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.11",
-      "resolved": "https://artifact.devsnc.com/repository/npm-all/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.11.tgz",
-      "integrity": "sha512-chRsz1K52/vj8Mfq/QOugVphlKPWlMh10V99qfH41hbGvwAU6xSPd681upO4bKiOr9+mRIZZW+EfJqY42ZzRyA==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.43.tgz",
+      "integrity": "sha512-B4otJRdPWIsmiSBf0uG7Z/+vMWmkufjz5MmYxubwKuZazDW14Zd3symga1N62QR4RT+kEFeHEgsXfZGyn/w0hw==",
       "cpu": [
         "arm64"
       ],
@@ -4576,9 +4638,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.11",
-      "resolved": "https://artifact.devsnc.com/repository/npm-all/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.11.tgz",
-      "integrity": "sha512-PYftgsTaGnfDK4m6/dty9ryK1FbLk+LosDJ/RJR2nkXGc8rd+WenXIlvHjWULiBVnS1RsjHHOXmTS4nDhe0v0w==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.43.tgz",
+      "integrity": "sha512-6zB6OnpViBxYy4tgY3v2i6AZY9fwkcHZ032UOwtwUuW1d19sdT07qF0kZe6/3UR1tUaK6jjg2rmVcUIBCEYVjQ==",
       "cpu": [
         "arm64"
       ],
@@ -4594,10 +4656,48 @@
         "node": ">=10"
       }
     },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.43.tgz",
+      "integrity": "sha512-coxE1ZWdB3uSDVNoEtYNrRi/1epvckZx9cTJ8ICUxTMTxGk+yvQ/Twacp3ruZSaMPGCriUjP86C37VhaT6nyRg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.43.tgz",
+      "integrity": "sha512-lXfLhs+LpBsD5inuYx+YDH5WsPPBQ95KPUiy8P5wq9ob9xKDZFqwNfU2QW6bGO8NqRO/H9JQomTSt5Yyh+FGfA==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.11",
-      "resolved": "https://artifact.devsnc.com/repository/npm-all/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.11.tgz",
-      "integrity": "sha512-DKtnJKIHiZdARyTKiX7zdRjiDS1KihkQWatQiCHMv+zc2sfwb4Glrodx2VLOX4rsa92NLR0Sw8WLcPEMFY1szQ==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.43.tgz",
+      "integrity": "sha512-07XnKwTmKy8TGOZG3D9fRnLWGynxPjwQnZLVmBFbo6F+7vHYzBIOuwXEhemrChBWb6yDNZsVCcMWCPX6FDD2xg==",
       "cpu": [
         "x64"
       ],
@@ -4614,9 +4714,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.11",
-      "resolved": "https://artifact.devsnc.com/repository/npm-all/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.11.tgz",
-      "integrity": "sha512-mUjjntHj4+8WBaiDe5UwRNHuEzLjIWBTSGTw0JT9+C9/Yyuh4KQqlcEQ3ro6GkHmBGXBFpGIj/o5VMyRWfVfWw==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.43.tgz",
+      "integrity": "sha512-TJc+bsSIaBh+hZvZ5GRtW/K1bw66TJ9vsUwvVIsZdiWxU5ObLwZvfcnZ3UpgVfMnFibRes9uriJrQNBHEEogRQ==",
       "cpu": [
         "x64"
       ],
@@ -4633,9 +4733,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.11",
-      "resolved": "https://artifact.devsnc.com/repository/npm-all/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.11.tgz",
-      "integrity": "sha512-ZkNNG5zL49YpaFzfl6fskNOSxtcZ5uOYmWBkY4wVAvgbSAQzLRVBp+xArGWh2oXlY/WgL99zQSGTv7RI5E6nzA==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.43.tgz",
+      "integrity": "sha512-jfd7s2/bUQYkOHLs+LWQNKZdmDa8+sufKLllhpWAhVQ2GDCwsHe3vR/j+OSiItZNtkzFuaawa3+SAKz9y5gYfw==",
       "cpu": [
         "arm64"
       ],
@@ -4649,9 +4749,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.11",
-      "resolved": "https://artifact.devsnc.com/repository/npm-all/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.11.tgz",
-      "integrity": "sha512-6XnzORkZCQzvTQ6cPrU7iaT9+i145oLwnin8JrfsLG41wl26+5cNQ2XV3zcbrnFEV6esjOceom9YO1w9mGJByw==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.43.tgz",
+      "integrity": "sha512-rLAE8JvucqEW1ZGohxPQrQWPBQeJG4+ypKbWfdlU/qmKScvCkxf9/Jxnzki1dkUQCQ7P5Enp13RlvqOlvx/32g==",
       "cpu": [
         "ia32"
       ],
@@ -4665,9 +4765,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.11",
-      "resolved": "https://artifact.devsnc.com/repository/npm-all/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.11.tgz",
-      "integrity": "sha512-IQ2n6af7XKLL6P1gIeZACskSxK8jWtoKpJWLZmdXTDj1MGzktUy4i+FvpdtxFmJWNavRWH1VmTr6kAubRDHeKw==",
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.43.tgz",
+      "integrity": "sha512-h8MLDHZcfIukwQWj03rIJZx1I0E81AYj2X7J/nGErG4nz+QAv6G1Z+peotvinL3lqpbo32tLYSMFo32/ySzxKg==",
       "cpu": [
         "x64"
       ],
@@ -4682,14 +4782,14 @@
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
-      "resolved": "https://artifact.devsnc.com/repository/npm-all/@swc/counter/-/counter-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
-      "version": "0.1.25",
-      "resolved": "https://artifact.devsnc.com/repository/npm-all/@swc/types/-/types-0.1.25.tgz",
-      "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
+      "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -4713,9 +4813,9 @@
       "license": "MIT"
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5793,9 +5893,9 @@
       }
     },
     "node_modules/avvio": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.2.0.tgz",
-      "integrity": "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.3.0.tgz",
+      "integrity": "sha512-g2tQ7LE7oOSqDfwEm3M+ZCMTJc7KiZCdJ4UwyZJb5ckTKyYu50OYmvv0mCFXPuYXoM4zkSt8zM9XQ9KCvxA74A==",
       "funding": [
         {
           "type": "github",
@@ -6682,7 +6782,6 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -7594,9 +7693,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.1.tgz",
-      "integrity": "sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
       "funding": [
         {
           "type": "github",
@@ -7605,8 +7704,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -8500,8 +8599,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -9840,9 +9938,9 @@
       "optional": true
     },
     "node_modules/livereload/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -10321,6 +10419,12 @@
       "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/nanotar": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/nanotar/-/nanotar-0.3.0.tgz",
+      "integrity": "sha512-Kv2JYYiCzt16Kt5QwAc9BFG89xfPNBx+oQL4GQXD9nLqPkZBiNaqaCWtwnbk/q7UVsTYevvM1b0UF8zmEI4pCg==",
+      "license": "MIT"
     },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
@@ -10843,9 +10947,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
-      "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
       "funding": [
         {
           "type": "github",
@@ -11363,7 +11467,6 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -11379,7 +11482,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11710,47 +11812,47 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.86.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.86.3.tgz",
-      "integrity": "sha512-iGtg8kus4GrsGLRDLRBRHY9dNVA78ZaS7xr01cWnS7PEMQyFtTqBiyCrfpTYTZXRWM94akzckYjh8oADfFNTzw==",
+      "version": "1.101.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.0.tgz",
+      "integrity": "sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==",
       "license": "MIT",
       "dependencies": {
-        "chokidar": "^4.0.0",
-        "immutable": "^5.0.2",
+        "chokidar": "^5.0.0",
+        "immutable": "^5.1.5",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {
         "sass": "sass.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.19.0"
       },
       "optionalDependencies": {
         "@parcel/watcher": "^2.4.1"
       }
     },
     "node_modules/sass/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/sass/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
@@ -12513,9 +12615,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "license": "BlueOak-1.0.0",
       "optional": true,
       "dependencies": {
@@ -13451,9 +13553,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -13484,9 +13586,9 @@
       }
     },
     "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modesty/fluent-mcp",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "MCP server for Fluent (ServiceNow SDK)",
   "keywords": [
     "Servicenow SDK",
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",
-    "@servicenow/sdk": "4.8.1",
+    "@servicenow/sdk": "4.9.0",
     "zod": "^4.4.3",
     "zod-to-json-schema": "^3.25.2"
   },

--- a/res/instruct/fluent_instruct_atf-ui-test-script.md
+++ b/res/instruct/fluent_instruct_atf-ui-test-script.md
@@ -1,0 +1,20 @@
+# Instructions for Fluent ATF UI Test Script (TestingLibrary) API
+
+Always reference `fluent_instruct_atf.md` and the ATF UI Test Script API specification for details.
+
+1. Start from the shared `Test()` scaffold in `fluent_instruct_atf.md`.
+2. Use `atf.uiTestScript.runTest()` **only** for custom UI that the standard `atf.form.*` / `atf.catalog.*` steps cannot reach — Angular/React widgets, embedded SPAs, custom workspaces, and `now-*` web components. Use the standard ATF categories for standard forms, catalog items, and pure server-side logic.
+3. Give every `Test()` and every step a unique `$id`. Steps execute sequentially.
+4. Keep the script body in a sibling `.js` file and reference it with `Now.include('./file.script.js')` for IDE support. Use an inline template literal only for a trivial one-liner, or when the script must interpolate a prior step's output (GEM interpolation is incompatible with `Now.include()`).
+5. Default file location: put the `.now.ts` and its `.js` files under `src/fluent/atf/` (unless the app already keeps ATF tests elsewhere).
+6. Inside the script body (all globals pre-injected — no imports):
+   - Navigate first with a **relative** URL: `await sn_atf.navigate('/now/path')`.
+   - Use `findBy*` for dynamic/async content (it polls), `getBy*` for content already present, `queryBy*` for conditional checks. Always `await` async queries.
+   - Use top-level `await` directly; never leave an async wrapper un-awaited (silent false pass).
+   - Strict mode: every query must resolve to exactly one element — disambiguate with `{ exact: true }`, `within()`, or `findAllBy*` + indexing.
+   - Commit `now-*` text inputs after typing by blurring: `await user.tab()`.
+   - Wrap element-state assertions in `await waitFor(() => expect(el)…)`. Never nest `findBy*` inside `waitFor()`. Put `timeout` in the query's opts object, not as a third argument.
+   - Max script length is 8000 characters — split long workflows across steps.
+7. Base queries on the **real rendered DOM** (roles/accessible names), not the authoring source — `now-*`/React components do not map 1:1 to HTML. Shadow DOM is pierced automatically.
+8. Assert the real outcome (verify the persisted record with an `atf.server.*` step), not just a UI success message. Assert display values, not stored values. Grant each impersonated persona the roles/ACLs its actions require.
+9. For multi-persona workflows, switch users with an `atf.server.impersonate()` step (its `user` is a sys_id) between `atf.uiTestScript.runTest()` steps; the within-script `sn_atf.impersonate('username')` takes a username.

--- a/res/prompt/coding_in_fluent.md
+++ b/res/prompt/coding_in_fluent.md
@@ -71,6 +71,13 @@ Fluent (ServiceNow SDK) is a TypeScript-based domain-specific language that allo
     - **ACL `field`** — the ACL `field` property accepts known schema field names, system columns, or the wildcard `'*'` (`keyof FullSchema<T> | SystemColumns | '*'`).
     - **Table `accessibleFrom`** — defaults to `'public'`; set `'package_private'` only to restrict cross-scope read access (note that doing so removes the table from some platform features such as Business Rules).
     - **CLI `now-sdk query`** — new read-only Table REST query command (surfaced as the `query_fluent_records` MCP tool) for inspecting instance data without leaving the terminal.
+10. **SDK v4.9.0 capabilities** — when generating code, take advantage of these additions where applicable:
+    - **UI Test Script (TestingLibrary) ATF step** — `atf.uiTestScript.runTest({ $id, script })` runs a TestingLibrary test body in the client test runner to test custom UI components (Angular/React widgets, embedded SPAs, custom workspaces, `now-*` web components) that the standard `atf.form.*` / `atf.catalog.*` steps cannot reach. Prefer `script: Now.include('./file.script.js')`; inside the body `screen`/`user`/`sn_atf`/`expect`/`waitFor`/`within`/`steps`/`params` are injected (no imports). See the `atf-ui-test-script` spec.
+    - **Multi-language choice labels** — a choice field's `choices` value may be an **array of `ChoiceConfig`** objects, each with a `language` (BCP 47) key, producing one translated `sys_choice` record per language: `choices: { 1: [{ label: 'Critical', language: 'en' }, { label: 'Critique', language: 'fr' }] }`. See the `column` spec.
+    - **`protectionPolicy` on AI Agent & AI Agentic Workflow** — `AiAgent` and `AiAgenticWorkflow` accept `protectionPolicy: 'read' | 'protected'` to control post-install edit/view access for other developers (same values as other `sys_policy`-backed APIs).
+    - **`Role.federatedId`** — the `Role` API accepts an optional `federatedId` string used to match a role to an externally federated role during identity federation.
+    - **Table index platform columns** — a table `index` entry's `element` may reference platform default columns (e.g. `'sys_created_on'`) in addition to custom columns.
+    - **Now Assist Skill Kit providers** — new LLM providers are selectable by name: `'Now LLM LTS Generic'`, `'Google Cloud Vertex AI'`, `'Amazon Bedrock'` (the `provider`/`model` fields are free strings — newer platform models are selectable by name).
 
 ## Working with Specific Metadata Types
 

--- a/res/snippet/fluent_snippet_atf-ui-test-script_0001.md
+++ b/res/snippet/fluent_snippet_atf-ui-test-script_0001.md
@@ -1,0 +1,33 @@
+# Test a custom UI component with a UI Test Script (TestingLibrary) step in ServiceNow ATF
+
+```typescript
+import { Test } from '@servicenow/sdk/core'
+import '@servicenow/sdk-core/global'
+Test({
+  $id: Now.ID['atf-ui-test-script_0001'], // fill in a valid GUID string or the name of the test
+  name: 'Custom UI: Submit Button Workflow', // string
+  description: 'Navigates to the app home, fills the Description field, clicks Submit, and asserts the confirmation appears — the success path of the submit workflow', // string
+  active: true, // boolean
+  failOnServerError: true // boolean
+}, (atf) => {
+  // Runs a TestingLibrary test body in the client test runner. In a real project prefer
+  // script: Now.include('./submit_button_test.script.js') to keep the body in a real .js file
+  // (IDE syntax highlighting); an inline template literal is used here for a self-contained example.
+  atf.uiTestScript.runTest({
+    $id: Now.ID['atf-ui-test-script_0001_step1'], // id the test step
+    script: `
+      await sn_atf.navigate('/now/my-app/home')
+
+      const descInput = await screen.findByLabelText('Description')
+      await user.type(descInput, 'ATF test submission')
+      await user.tab() // commit a now-* input by blurring (it commits on change, not per keystroke)
+
+      const submitBtn = await screen.findByRole('button', { name: 'Submit', exact: true })
+      await user.click(submitBtn)
+
+      const confirmation = await screen.findByText('Submitted successfully', { timeout: 10000 })
+      await waitFor(() => expect(confirmation).toBeVisible())
+    `,
+  })
+})
+```

--- a/res/snippet/fluent_snippet_form_0002.md
+++ b/res/snippet/fluent_snippet_form_0002.md
@@ -20,8 +20,7 @@ const example_section_1 = Record({ // create a first section to store the standa
     $id: Now.ID['section_1'],
     table: 'sys_ui_section',
     data: {
-        name: 'incident',
-        table: 'incident',
+        name: 'incident', // the table name the section is for (sys_ui_section has no separate `table` column)
         view: default_view,
         caption: '' // no caption for the first section
     }
@@ -31,8 +30,7 @@ const example_section_2 = Record({ // create a second section to store some addi
     $id: Now.ID['section_2'],
     table: 'sys_ui_section',
     data: {
-        name: 'incident',
-        table: 'incident',
+        name: 'incident', // the table name the section is for (sys_ui_section has no separate `table` column)
         view: default_view,
         caption: 'Additional fields'
     }

--- a/res/spec/fluent_spec_ai-agent-workflow.md
+++ b/res/spec/fluent_spec_ai-agent-workflow.md
@@ -7,6 +7,7 @@ AiAgenticWorkflow({
   name: '', // string, mandatory - display name of the AI Agentic Workflow
   description: '', // string, mandatory - description of the AI Agentic Workflow
   active: true, // boolean, optional - whether the workflow is active (default: true)
+  protectionPolicy: '', // 'read' | 'protected', optional (SDK v4.9.0+) - post-install access control for other developers: 'read' = others can view but not change the configuration; 'protected' = others cannot change the record; omit to allow customization
   executionMode: '', // 'copilot' | 'autopilot', optional - execution mode (default: 'copilot')
   recordType: '', // 'custom' | 'template' | 'aia_internal', optional - record type classification (default: 'template')
   contextProcessingScript: '', // function | string, optional - script that processes context for the workflow (supports Now.include())

--- a/res/spec/fluent_spec_ai-agent.md
+++ b/res/spec/fluent_spec_ai-agent.md
@@ -10,6 +10,7 @@ AiAgent({
   securityAcl: {}, // SecurityAclUserAccessConfig, MANDATORY - auto-generates `sys_security_acl` + `sys_security_acl_role` records controlling who can invoke the agent
     // Shape: { $id: Now.ID['…'], type: 'Specific role' | …, roles: string[] (role names or sys_ids) }
   active: true, // boolean, optional - controls whether the agent is available for use (default: true)
+  protectionPolicy: '', // 'read' | 'protected', optional (SDK v4.9.0+) - post-install access control for other developers: 'read' = others can view but not change the configuration; 'protected' = others cannot change the record; omit to allow customization
   agentDescriptor: '', // AiAgentDescriptorType | '', optional (SDK v4.7.0+) - classifies how the agent was created / its access requirement; set on `sn_aia_agent_config`
     // Values: 'require_caller_id' | 'created_by_ai_agent_advisor' | 'created_by_build_agent'. Defaults to ''
   agentType: '', // 'internal' | 'external' | 'voice' | 'aia_internal', optional - specifies agent type (default: 'internal')

--- a/res/spec/fluent_spec_atf-ui-test-script.md
+++ b/res/spec/fluent_spec_atf-ui-test-script.md
@@ -1,0 +1,55 @@
+#**Context:** UI Test Script (TestingLibrary) ATF API spec (SDK v4.9.0+). The `atf.uiTestScript.runTest()` step runs a TestingLibrary test body in the client test runner to test **custom UI components** — Angular/React widgets embedded in workspaces, custom SPAs or UI-page apps, and `now-*` web components (custom elements with shadow DOM). Use it only when a UI cannot be tested through the standard `atf.form.*` or `atf.catalog.*` steps. The script body runs in an async context with all API globals injected — no imports are needed inside the script.
+```typescript
+// Fluent ATF Test with a UI Test Script (TestingLibrary) step.
+// Imports (shown in the shared ATF scaffold): import { Test } from '@servicenow/sdk/core'; import '@servicenow/sdk/global'
+Test(
+  {
+    $id: Now.ID[''], // string | guid, mandatory - unique test id
+    name: '', // string, mandatory - e.g. 'Custom UI: <Workflow Name>'
+    description: '', // string, mandatory - what it validates AND how (name the component, action, and assertion)
+    active: true, // boolean, mandatory
+  },
+  (atf) => {
+    // Runs a TestingLibrary test script in the client test runner.
+    atf.uiTestScript.runTest({
+      $id: Now.ID[''], // string | guid, mandatory - unique step id
+      script: Now.include('./my_workflow_test.script.js'), // string | ReturnType<typeof Now.include>, mandatory
+        // Prefer Now.include('./file.script.js') to keep the body in a real .js file (IDE support).
+        // Use an inline template literal ONLY for trivial one-liners or when interpolating a prior step's output.
+        // Max 8000 characters. `await` is supported. No imports needed — all globals are injected.
+    }): void
+  }
+)
+
+// ─── Script body globals (available inside `script`, NO imports) ───
+// screen  — DOM queries. Prefixes: getBy* (sync, immediately present), findBy* (async, polls — for dynamic content),
+//           queryBy* (async, null if 0 matches — conditional checks), getAllBy* / findAllBy* / queryAllBy* (arrays).
+//           Suffixes: ByRole, ByText, ByLabelText, ByPlaceholderText, ByTestId, ByDisplayValue, BySelector, ByAltText, ByTitle.
+//           Query options go in the opts object: findByRole('button', { name: 'Submit', exact: true, timeout: 15000 }).
+//           Strict mode: every getBy*/findBy*/queryBy* must resolve to exactly ONE element. Shadow DOM is pierced automatically.
+// user    — interactions (element is the first argument): click, dblClick, type, clear, selectOptions, deselectOptions,
+//           upload, hover, unhover, keyboard, tab, copy, cut, paste. (No .fill/.impersonate/.navigate/.evaluate.)
+// sn_atf  — ServiceNow APIs: navigate(url) (prefer relative), reload, goBack, goForward, evaluate(fn) (access g_form/g_user),
+//           impersonate(userName) (username OR sys_id; auto-reverts at step end), waitForElementToBeRemoved(el, opts),
+//           delay(ms) (last resort), querySelector/querySelectorAll/getActiveElement (shadow-piercing), upload helpers.
+// expect  — element assertions (sync, throw): toBeVisible, toBeEnabled, toBeDisabled, toBeChecked, toHaveTextContent,
+//           toHaveValue, toHaveAttribute, toHaveFocus, toBeInTheDocument, ... (invert with .not); plus plain-value
+//           assertions: toBe, toEqual, toContain, toMatch, toHaveLength, toBeGreaterThan(OrEqual), ...
+// waitFor(cb, { timeout, interval }) — retries cb until it stops throwing. Wrap element-state assertions in it by default.
+//           NEVER nest findBy* inside waitFor() (findBy* already polls).
+// within(el) — scoped Screen (all query variants). Does NOT cross a <slot> boundary.
+// steps(stepSysId) — prior-step output, supports dotwalking (steps(id).record_id). Use == for string comparison.
+// params(name) — parameterized-test value.
+
+// ─── Multi-persona (impersonation) ───
+// Within a single script: `await sn_atf.impersonate('username')` (auto-reverts at step end).
+// Across steps: place an `atf.server.impersonate({ $id, user: '<sys_user sys_id>' })` step BETWEEN uiTestScript steps
+//   (that step's `user` is a reference field — a sys_id, NOT a username). Split the script at every persona boundary.
+
+// ─── Passing data between steps ───
+// Interpolate a prior step return value's PROPERTY ACCESS in an inline template literal; the build converts it to a GEM
+// expression the ATF framework substitutes at run time. Now.include() cannot be used when the script needs interpolation.
+//   const insert = atf.server.recordInsert({ $id: Now.ID['ins'], table: 'sn_travel_request', fieldValues: { short_description: 'x' } })
+//   atf.uiTestScript.runTest({ $id: Now.ID['view'], script: `await sn_atf.navigate('/now/app/record/' + '${insert.record_id}')` })
+// Do NOT interpolate module-level constants or external (DB-lookup) values — write those as inline literals.
+```

--- a/res/spec/fluent_spec_column.md
+++ b/res/spec/fluent_spec_column.md
@@ -44,6 +44,15 @@ ChoiceColumn({
  readOnly: false // boolean
 }): ChoiceColumn // returns a ChoiceColumn object
 
+// ─── Choice values (`choices`) — applies to ChoiceColumn and any column exposing `choices` ───
+// `choices` is `Record<string | number, string | ChoiceConfig | ChoiceConfig[]>`. Each KEY is the STORED value; the value is:
+//   • a plain label string, e.g. { 1: 'High' }
+//   • a ChoiceConfig object: { label: 'High', sequence?: number, hint?: string, inactive?: boolean, dependentValue?: string | number, inactiveOnUpdate?: boolean, synonyms?: string[] }
+//   • an ARRAY of ChoiceConfig — produces MULTIPLE `sys_choice` records for the same stored value. Use this to supply
+//     labels in MULTIPLE LANGUAGES (SDK v4.9.0+) via the `language` key, or to define dependent-value variants:
+//       choices: { 1: [ { label: 'Critical', sequence: 1, language: 'en' }, { label: 'Critique', sequence: 1, language: 'fr' } ] }
+//   `language` is a BCP 47 tag (e.g. 'en', 'fr'); defaults to the project's `defaultLanguage` in now.config.json.
+
 ReferenceColumn({
  active: false, // boolean
  attributes: {}, // object, snake_case name value pairs, see attribute list

--- a/res/spec/fluent_spec_form.md
+++ b/res/spec/fluent_spec_form.md
@@ -165,8 +165,7 @@ const example_section = Record({
     $id: Now.ID['my_section'],
     table: 'sys_ui_section',
     data: {
-        name: '',      // string — table name the section is for
-        table: '',     // string — table name
+        name: '',      // string — table name the section is for (sys_ui_section has no separate `table` column)
         view: example_view, // Record<'sys_ui_view'> | sys_id string | default_view
         caption: ''    // string, optional — section title
     }

--- a/res/spec/fluent_spec_now-assist-skill-config.md
+++ b/res/spec/fluent_spec_now-assist-skill-config.md
@@ -32,8 +32,10 @@ NowAssistSkillConfig(
   // Second argument: Prompt Configuration
   {
     providers: [], // ProviderPromptConfig[], mandatory - at least one provider with prompts
-      // Each provider: { provider: string (e.g., 'Now LLM Service', 'Azure OpenAI', 'Open AI', 'Google Gemini', 'AWS Claude'), providerAPI?: object, prompts: PromptSettings[], defaultPrompt?: string, defaultPromptVersion?: number }
+      // Each provider: { provider: string, providerAPI?: object, prompts: PromptSettings[], defaultPrompt?: string, defaultPromptVersion?: number }
+      // `provider` is a free string; known providers (SDK v4.9.0): 'Now LLM Service', 'Now LLM Generic', 'Now LLM LTS Generic', 'Azure OpenAI', 'Open AI', 'Google Gemini', 'Google Cloud Vertex AI', 'AWS Claude', 'Amazon Bedrock', 'IBM Watson', 'Perplexity', 'Aleph Alpha', 'Custom LLM Provider'
       // Each prompt: { $id, name, versions: [{ $id, model: string, temperature?: number, maxTokens?: number, promptState?: 'draft'|'published'|'test', prompt: string | ((p) => string) }] }
+      //   `model` is a free string naming a platform-available model (e.g. 'llm_generic_small_v2', 'gpt-4o-mini'); newer models are selectable by name as the platform/provider adds them.
       // In prompt builder callbacks, access inputs via p.input.fieldName and tool outputs via p.tool.ToolName.output
     defaultProvider: '', // string, optional - name of default provider (must match a provider's name)
   }

--- a/res/spec/fluent_spec_role.md
+++ b/res/spec/fluent_spec_role.md
@@ -7,6 +7,7 @@ Role({
     assignableBy: '', // string, mandatory
     canDelegate: true, // boolean, mandatory
     elevatedPrivilege: false, // boolean, mandatory
+    federatedId: '', // string, optional (SDK v4.9.0+) - identifier used to match this role to an externally federated role during identity federation
     grantable: true, // boolean, mandatory
     containsRoles: [get_sys_id('sys_user_role', '')], // array of Record<'sys_user_role'>, optional, either sys_id or Role object
     scopedAdmin: false, // boolean, mandatory

--- a/res/spec/fluent_spec_table.md
+++ b/res/spec/fluent_spec_table.md
@@ -25,7 +25,7 @@ Table({
         {
             name: '', // string, mandatory
             unique: false, // boolean, mandatory
-            element: '', // string | string[], mandatory
+            element: '', // string | string[], mandatory - column name(s) making up the index; accepts custom columns and platform default columns (e.g. 'sys_created_on', 'sys_updated_on') as of SDK v4.9.0
         }
     ],
     autoNumber: { // Auto-numbering configuration

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,7 @@ export enum ServiceNowMetadataType {
   ATF_SERVER = 'atf-server',
   ATF_SERVER_CATALOG_ITEM = 'atf-server-catalog-item',
   ATF_SERVER_RECORD = 'atf-server-record',
+  ATF_UI_TEST_SCRIPT = 'atf-ui-test-script',
   BUSINESS_RULE = 'business-rule',
   CATALOG_CLIENT_SCRIPT = 'catalog-client-script',
   CATALOG_ITEM = 'catalog-item',

--- a/test/sdk490-types.integration.test.ts
+++ b/test/sdk490-types.integration.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Integration tests for SDK v4.9.0 metadata coverage.
+ * These tests read actual resource files from disk (no mocks) to verify content correctness
+ * for the new metadata type (atf-ui-test-script) and the changed APIs introduced in v4.9.0
+ * (Role.federatedId, AiAgent/AiAgenticWorkflow protectionPolicy, multi-language choice labels,
+ * table index platform columns, and the new NASK LLM providers).
+ *
+ * Source-of-truth directive: the locally-installed 4.9.0 package wins wherever it diverges from
+ * the release note. Two release-note claims that the installed docs do NOT corroborate are
+ * asserted as corrections here:
+ *   - Form `table_field.field` "any string" — docs describe it as a schema column name; our spec
+ *     already types it `string`, so no loosening is claimed.
+ *   - The 4 named NASK model strings (gpt-5-mini, etc.) appear nowhere in the installed package
+ *     (`model` is a free `string`); we do not hardcode them as a documented enum.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { ServiceNowMetadataType } from '../src/types.js';
+
+const PROJECT_ROOT = process.cwd();
+const RES_DIR = path.join(PROJECT_ROOT, 'res');
+const SPEC_DIR = path.join(RES_DIR, 'spec');
+const INSTRUCT_DIR = path.join(RES_DIR, 'instruct');
+const SNIPPET_DIR = path.join(RES_DIR, 'snippet');
+const PROMPT_DIR = path.join(RES_DIR, 'prompt');
+
+const read = (dir: string, file: string) => fs.readFileSync(path.join(dir, file), 'utf-8');
+
+const NEW_TYPES: Array<[keyof typeof ServiceNowMetadataType, string]> = [
+  ['ATF_UI_TEST_SCRIPT', 'atf-ui-test-script'],
+];
+
+describe('SDK v4.9.0 Types - Integration Tests', () => {
+  describe('Enum completeness', () => {
+    it.each(NEW_TYPES)('should have the new v4.9.0 enum entry %s', (key, value) => {
+      expect(ServiceNowMetadataType[key]).toBe(value);
+    });
+  });
+
+  describe('New resource files exist for each new type', () => {
+    it.each(NEW_TYPES)('%s has spec/instruct/snippet coverage (%s)', (_key, value) => {
+      expect(fs.existsSync(path.join(SPEC_DIR, `fluent_spec_${value}.md`))).toBe(true);
+      expect(fs.existsSync(path.join(INSTRUCT_DIR, `fluent_instruct_${value}.md`))).toBe(true);
+      const snippets = fs.readdirSync(SNIPPET_DIR)
+        .filter((f) => f.startsWith(`fluent_snippet_${value}_`) && f.endsWith('.md'));
+      expect(snippets.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('atf-ui-test-script (UI Test Script / TestingLibrary) resources', () => {
+    it('spec should document the runTest step and the injected script globals', () => {
+      const content = read(SPEC_DIR, 'fluent_spec_atf-ui-test-script.md');
+      for (const term of [
+        'atf.uiTestScript.runTest', 'Now.include', 'script', 'screen', 'user',
+        'sn_atf', 'waitFor', 'within', '8000',
+      ]) {
+        expect(content).toContain(term);
+      }
+    });
+
+    it('instruct should reference the shared ATF scaffold and the src/fluent/atf location', () => {
+      const content = read(INSTRUCT_DIR, 'fluent_instruct_atf-ui-test-script.md');
+      expect(content).toContain('fluent_instruct_atf.md');
+      expect(content).toContain('atf.uiTestScript.runTest');
+      expect(content).toContain('src/fluent/atf/');
+    });
+
+    it('snippet 0001 should define a Test with a uiTestScript.runTest step', () => {
+      const content = read(SNIPPET_DIR, 'fluent_snippet_atf-ui-test-script_0001.md');
+      expect(content).toContain('Test(');
+      expect(content).toContain('atf.uiTestScript.runTest(');
+      expect(content).toContain('screen.findBy');
+    });
+  });
+
+  describe('Changed API resources (v4.9.0)', () => {
+    it('role spec should document the federatedId property', () => {
+      const content = read(SPEC_DIR, 'fluent_spec_role.md');
+      expect(content).toContain('federatedId');
+    });
+
+    it('ai-agent spec should document protectionPolicy', () => {
+      const content = read(SPEC_DIR, 'fluent_spec_ai-agent.md');
+      expect(content).toContain('protectionPolicy');
+      expect(content).toContain("'read' | 'protected'");
+    });
+
+    it('ai-agent-workflow spec should document protectionPolicy', () => {
+      const content = read(SPEC_DIR, 'fluent_spec_ai-agent-workflow.md');
+      expect(content).toContain('protectionPolicy');
+      expect(content).toContain("'read' | 'protected'");
+    });
+
+    it('column spec should document multi-language choice labels (ChoiceConfig array + language)', () => {
+      const content = read(SPEC_DIR, 'fluent_spec_column.md');
+      for (const term of ['ChoiceConfig', 'language', 'BCP 47', 'MULTIPLE LANGUAGES']) {
+        expect(content).toContain(term);
+      }
+    });
+
+    it('table spec index element should note platform default columns', () => {
+      const content = read(SPEC_DIR, 'fluent_spec_table.md');
+      expect(content).toContain('sys_created_on');
+    });
+
+    it('now-assist-skill-config spec should list the new v4.9.0 LLM providers', () => {
+      const content = read(SPEC_DIR, 'fluent_spec_now-assist-skill-config.md');
+      for (const provider of ['Now LLM LTS Generic', 'Google Cloud Vertex AI', 'Amazon Bedrock']) {
+        expect(content).toContain(provider);
+      }
+    });
+  });
+
+  describe('Cross-cutting capabilities in coding_in_fluent prompt (v4.9.0)', () => {
+    it('should list SDK v4.9.0 capabilities including the new type and changed APIs', () => {
+      const content = read(PROMPT_DIR, 'coding_in_fluent.md');
+      expect(content).toContain('SDK v4.9.0');
+      for (const term of [
+        'atf.uiTestScript.runTest', 'Multi-language choice labels', 'protectionPolicy',
+        'federatedId', 'Amazon Bedrock',
+      ]) {
+        expect(content).toContain(term);
+      }
+    });
+  });
+
+  describe('Release-note corrections (installed package = source of truth)', () => {
+    it('form spec keeps table_field.field typed as a schema column name (no "any string" loosening)', () => {
+      const content = read(SPEC_DIR, 'fluent_spec_form.md');
+      // The installed docs describe `field` as "Column name from the table schema"; do not claim "any string".
+      expect(content).not.toContain('any string');
+      expect(content).toContain('column name from the table schema');
+    });
+
+    it('now-assist-skill-config spec does NOT hardcode the undocumented 4.9.0 model strings', () => {
+      const content = read(SPEC_DIR, 'fluent_spec_now-assist-skill-config.md');
+      // These model names appear nowhere in the installed package; model is a free string.
+      for (const model of ['gpt-5-mini', 'gemini_small', 'claude-haiku-4-5', 'llm_generic_small_v2-lts']) {
+        expect(content).not.toContain(model);
+      }
+    });
+
+    it('scheduled-script spec already documents object inputs and protectionPolicy (no change needed in 4.9.0)', () => {
+      const content = read(SPEC_DIR, 'fluent_spec_scheduled-script.md');
+      expect(content).toContain('executionTime');
+      expect(content).toContain('maxDrift');
+      expect(content).toContain('protectionPolicy');
+    });
+  });
+});


### PR DESCRIPTION
feat: upgrade @servicenow/sdk 4.8.1 → 4.9.0 (v0.5.0)

  Track SDK 4.9.0 — a maintenance/bug-fix release with select authoring-surface
  additions. Installed package treated as source of truth over the release note.

  Added
  - New metadata type `atf-ui-test-script` (enum 64 → 65): the
    `atf.uiTestScript.runTest()` ATF step for TestingLibrary tests of custom UI /
    `now-*` web components. Adds spec + instruct + snippet and the
    ServiceNowMetadataType enum entry.

  Changed
  - column: document multi-language choice labels (`ChoiceConfig[]` with a BCP-47
    `language` key per entry).
  - ai-agent, ai-agent-workflow: add `protectionPolicy: 'read' | 'protected'`.
  - role: add `federatedId`.
  - table: note index `element` may reference platform default columns
    (e.g. `sys_created_on`).
  - now-assist-skill-config: add new LLM providers (Now LLM LTS Generic,
    Google Cloud Vertex AI, Amazon Bedrock); clarify provider/model are free strings.
  - coding_in_fluent prompt: add "SDK v4.9.0 capabilities" section.
  - README: SDK version, 65-type count, "What's new in 4.9.0", requirements.

  Fixed
  - form_0002 snippet: 4.9.0 tightened `Data<"sys_ui_section">` to drop `table`,
    which broke the build; remove the invalid property from the snippet and the
    matching Record-fallback in the form spec.

  Test
  - Add test/sdk490-types.integration.test.ts (15 tests) covering the new type,
    changed APIs, and release-note corrections (Form `field` not loosened to "any
    string"; the four named NASK models absent from the package are not hardcoded).

  Verified: build + lint clean; 447/447 tests; specs 65/65, instructs 66/66,
  snippets 0 unexpected failures.