### PR TITLE
feat: addd MCPB packaging, synchronize doc, add deterministic dual-er…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # Misc
 *.tgz
+*.mcpb
 *.log
 
 # TypeScript
@@ -49,5 +50,4 @@ build/
 # OS generated files
 Thumbs.db
 Desktop.ini
-
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Built for [@servicenow/sdk@v4.9.0](https://github.com/ServiceNow/sdk/releases#re
 - **API Documentation Lookup** - `explain_fluent_api` returns SDK docs for any Fluent API or guide — no project required
 - **Lazy Auto-Authentication** - Detects and caches an auth profile only when an auth-requiring command or `check_auth_status` needs it
 - **Explicit Project Context** - Resolves each project command from its `workingDirectory` argument, the initialized session, or `FLUENT_MCP_WORKING_DIR`, then fails with actionable guidance instead of guessing
+- **MCPB Bundle** - Builds a self-contained `.mcpb` distribution with the server, resources, and production dependencies
 - **Client-Friendly Schemas** - Optional inputs advertise their canonical value types while the enforced schema accepts `null` as an omitted-value compatibility form
 
 This MCP server implements the [Model Context Protocol](https://modelcontextprotocol.io) specification with the following capabilities:
@@ -26,11 +27,11 @@ This MCP server implements the [Model Context Protocol](https://modelcontextprot
 
 ### Project Context & Sessions
 
-The server requires **no client capabilities** and issues **no server→client requests**: Roots, Sampling, and Elicitation are not used (MCP 2026-07-28 removed server-initiated requests, and all input arrives with the `tools/call` arguments).
+The server requires **no client capabilities** and issues **no server→client requests**: Roots, Sampling, and Elicitation are not used (MCP 2026-07-28 removed server-initiated requests, and all input arrives with the `tools/call` arguments). Automatic workspace detection through Roots is gone for every client, including MCPB hosts.
 
 - **Session Management** - Tracks the directory established by `init_fluent_app` for subsequent project commands
-- **Working Directory Resolution** - `workingDirectory` tool argument → initialized session → `FLUENT_MCP_WORKING_DIR` → actionable failure. Accepted paths are non-empty absolute paths other than the filesystem root. The server never guesses from its process cwd or installed package directory.
-- **Non-interactive `init_fluent_app`** - Intent-specific arguments must be supplied with the call (creation: `appName`, `packageName`, `scopeName`, `template`; conversion: `from`); a missing argument fails with an error naming exactly what is absent
+- **Working Directory Resolution** - `workingDirectory` tool argument → initialized session → `FLUENT_MCP_WORKING_DIR` → actionable failure. Accepted paths are non-empty absolute paths other than the filesystem root. The server never guesses from its process cwd or installed package directory. Clients must pass `workingDirectory` or configure `FLUENT_MCP_WORKING_DIR` when no session directory exists.
+- **Non-interactive `init_fluent_app`** - Intent-specific arguments must be supplied with the call (creation: `appName`, `packageName`, `scopeName`, `template`; conversion: `from`); a missing argument fails with an error naming exactly what is absent. The tool does not prompt or elicit missing values.
 - **Error Handling** - Comprehensive error messages with actionable guidance
 - **Type Safety** - Full TypeScript implementation with strict typing
 
@@ -49,8 +50,21 @@ The server requires **no client capabilities** and issues **no server→client r
 # Test with MCP Inspector
 npx @modelcontextprotocol/inspector npx @modesty/fluent-mcp
 
+# Build the optional self-contained MCPB distribution
+npm run bundle
+
 # Or use in your MCP client (see Configuration below)
 ```
+
+### MCPB Distribution
+
+The optional `npm run bundle` command produces `fluent-mcp-<version>.mcpb`. The bundle contains `dist/`, `res/`, and production dependencies, and its `manifest.json` declares all 15 tools. MCPB hosts expose these user-configurable values to the server:
+
+- `FLUENT_MCP_WORKING_DIR` — optional default project directory; otherwise pass `workingDirectory` on project-aware tool calls
+- `SN_INSTANCE_URL` — optional instance URL for lazy authentication validation
+- `SN_AUTH_TYPE` — authentication type (`basic` or `oauth`, default `oauth`)
+
+The npm package remains the primary distribution channel. MCPB does not restore Roots-based workspace detection or interactive `init_fluent_app` prompting.
 
 **Example prompt:**
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://raw.githubusercontent.com/anthropics/mcpb/main/schemas/mcpb-manifest-v0.4.schema.json",
+  "manifest_version": "0.4",
+  "name": "fluent-mcp",
+  "display_name": "Fluent MCP",
+  "version": "0.6.0",
+  "description": "MCP server for ServiceNow Fluent SDK commands and development resources.",
+  "long_description": "Fluent MCP provides ServiceNow Fluent SDK command tools, API specifications, authoring instructions, code snippets, and development prompts over MCP.",
+  "author": {
+    "name": "Modesty Zhang",
+    "email": "modestyz@hotmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/modesty/fluent-mcp"
+  },
+  "homepage": "https://github.com/modesty/fluent-mcp",
+  "server": {
+    "type": "node",
+    "entry_point": "dist/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": [
+        "${__dirname}/dist/index.js"
+      ],
+      "env": {
+        "FLUENT_MCP_WORKING_DIR": "${user_config.FLUENT_MCP_WORKING_DIR}",
+        "SN_INSTANCE_URL": "${user_config.SN_INSTANCE_URL}",
+        "SN_AUTH_TYPE": "${user_config.SN_AUTH_TYPE}"
+      }
+    }
+  },
+  "tools": [
+    { "name": "build_fluent_app", "description": "Build a Fluent application." },
+    { "name": "check_auth_status", "description": "Check configured ServiceNow authentication." },
+    { "name": "clean_fluent_app", "description": "Clean Fluent application output." },
+    { "name": "deploy_fluent_app", "description": "Deploy a Fluent application to ServiceNow." },
+    { "name": "download_fluent_app", "description": "Download application metadata from ServiceNow." },
+    { "name": "download_fluent_dependencies", "description": "Download Fluent application dependencies." },
+    { "name": "explain_fluent_api", "description": "Look up Fluent SDK API and guide documentation." },
+    { "name": "fluent_transform", "description": "Transform metadata into Fluent source code." },
+    { "name": "get-api-spec", "description": "Read a Fluent metadata API specification." },
+    { "name": "get-instruct", "description": "Read Fluent metadata authoring guidance." },
+    { "name": "get-snippet", "description": "Read a Fluent metadata code snippet." },
+    { "name": "init_fluent_app", "description": "Initialize or convert a Fluent application." },
+    { "name": "pack_fluent_app", "description": "Package a built Fluent application." },
+    { "name": "query_fluent_records", "description": "Run a read-only ServiceNow Table REST query." },
+    { "name": "sdk_info", "description": "Read ServiceNow Fluent SDK version or help." }
+  ],
+  "keywords": ["mcp", "servicenow", "fluent", "sdk"],
+  "license": "MIT",
+  "user_config": {
+    "FLUENT_MCP_WORKING_DIR": {
+      "type": "directory",
+      "title": "Fluent project directory",
+      "description": "Absolute Fluent project path used when a tool call does not provide workingDirectory.",
+      "default": ""
+    },
+    "SN_INSTANCE_URL": {
+      "type": "string",
+      "title": "ServiceNow instance URL",
+      "description": "Optional instance URL used for lazy authentication validation.",
+      "default": ""
+    },
+    "SN_AUTH_TYPE": {
+      "type": "string",
+      "title": "ServiceNow authentication type",
+      "description": "Authentication method for lazy validation: basic or oauth.",
+      "default": "oauth"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "fluent-mcp": "dist/index.js"
       },
       "devDependencies": {
+        "@anthropic-ai/mcpb": "2.1.2",
         "@eslint/js": "^10.0.1",
         "@rollup/plugin-commonjs": "^29.0.3",
         "@rollup/plugin-json": "^6.1.0",
@@ -38,6 +39,285 @@
       },
       "engines": {
         "node": ">=20.18.0"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/mcpb/-/mcpb-2.1.2.tgz",
+      "integrity": "sha512-goRbBC8ySo7SWb7tRzr+tL6FxDc4JPTRCdgfD2omba7freofvjq5rom1lBnYHZHo6Mizs1jAHJeN53aZbDoy8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/prompts": "^6.0.1",
+        "commander": "^13.1.0",
+        "fflate": "^0.8.2",
+        "galactus": "^1.0.0",
+        "ignore": "^7.0.5",
+        "node-forge": "^1.3.2",
+        "pretty-bytes": "^5.6.0",
+        "zod": "^3.25.67",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "mcpb": "dist/cli/cli.js"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/@inquirer/checkbox": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-3.0.1.tgz",
+      "integrity": "sha512-0hm2nrToWUdD6/UHnel/UKGdk1//ke5zGUpHIvk5ZWmaKezlGxZkOJXNSWsdxO/rEqTkbB3lNC2J6nBElV2aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/@inquirer/confirm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-4.0.1.tgz",
+      "integrity": "sha512-46yL28o2NJ9doViqOy0VDcoTzng7rAb6yPQKU7VDLqkmbCaH4JqK4yk4XqlzNWy9PVC5pG1ZUXPBQv+VqnYs2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/@inquirer/core": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
+      "integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^22.5.5",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^1.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/@inquirer/editor": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-3.0.1.tgz",
+      "integrity": "sha512-VA96GPFaSOVudjKFraokEEmUQg/Lub6OXvbIEZU1SDCmBzRkHGhxoFAVaF30nyiB4m5cEbDgiI2QRacXZ2hw9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/@inquirer/expand": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-3.0.1.tgz",
+      "integrity": "sha512-ToG8d6RIbnVpbdPdiN7BCxZGiHOTomOX94C2FaT5KOHupV40tKEDozp12res6cMIfRKrXLJyexAZhWVHgbALSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/@inquirer/input": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-3.0.1.tgz",
+      "integrity": "sha512-BDuPBmpvi8eMCxqC5iacloWqv+5tQSJlUafYWUe31ow1BVXjW2a5qe3dh4X/Z25Wp22RwvcaLCc2siHobEOfzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/@inquirer/number": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-2.0.1.tgz",
+      "integrity": "sha512-QpR8jPhRjSmlr/mD2cw3IR8HRO7lSVOnqUvQa8scv1Lsr3xoAMMworcYW3J13z3ppjBFBD2ef1Ci6AE5Qn8goQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/@inquirer/password": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-3.0.1.tgz",
+      "integrity": "sha512-haoeEPUisD1NeE2IanLOiFr4wcTXGWrBOyAyPZi1FfLJuXOzNmxCJPgUrGYKVh+Y8hfGJenIfz5Wb/DkE9KkMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/@inquirer/prompts": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-6.0.1.tgz",
+      "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^3.0.1",
+        "@inquirer/confirm": "^4.0.1",
+        "@inquirer/editor": "^3.0.1",
+        "@inquirer/expand": "^3.0.1",
+        "@inquirer/input": "^3.0.1",
+        "@inquirer/number": "^2.0.1",
+        "@inquirer/password": "^3.0.1",
+        "@inquirer/rawlist": "^3.0.1",
+        "@inquirer/search": "^2.0.1",
+        "@inquirer/select": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/@inquirer/rawlist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-3.0.1.tgz",
+      "integrity": "sha512-VgRtFIwZInUzTiPLSfDXK5jLrnpkuSOh1ctfaoygKAdPqjcjKYmGh6sCY1pb0aGnCGsmhUxoqLDUAU0ud+lGXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/@inquirer/search": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-2.0.1.tgz",
+      "integrity": "sha512-r5hBKZk3g5MkIzLVoSgE4evypGqtOannnB3PKTG9NRZxyFRKcfzrdxXXPcoJQsxJPzvdSU2Rn7pB7lw0GCmGAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/@inquirer/select": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-3.0.1.tgz",
+      "integrity": "sha512-lUDGUxPhdWMkN/fHy1Lk7pF3nK1fh/gqeyWXmctefhxLYxlDsc7vsPBEpxrfVGDsVdyYJsiJoD4bJ1b623cV1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/@inquirer/type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
+      "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mute-stream": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@anthropic-ai/mcpb/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4949,6 +5229,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT"
     },
+    "node_modules/@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
@@ -4970,6 +5260,13 @@
       "version": "2.0.3",
       "resolved": "https://artifact.devsnc.com/repository/npm-all/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "dev": true,
       "license": "MIT"
     },
@@ -7302,6 +7599,41 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/external-editor/node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/external-editor/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-content-type-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
@@ -7645,6 +7977,20 @@
       "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "license": "ISC"
     },
+    "node_modules/flora-colossus": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flora-colossus/-/flora-colossus-2.0.0.tgz",
+      "integrity": "sha512-dz4HxH6pOvbUzZpZ/yXhafjbR2I8cenK5xL0KtBFb7U2ADsR+OwXifnxZjij/pZWF775uSCMzWVd+jDik2H2IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -7683,6 +8029,21 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/fs-minipass": {
       "version": "3.0.3",
@@ -7725,6 +8086,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/galactus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/galactus/-/galactus-1.0.0.tgz",
+      "integrity": "sha512-R1fam6D4CyKQGNlvJne4dkNF+PvUUl7TAJInvTGa9fti9qAv95quQz29GXapA4d8Ec266mJJxFVh82M4GIIGDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "flora-colossus": "^2.0.0",
+        "fs-extra": "^10.1.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/gensync": {
@@ -9436,6 +9812,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/jsonschema": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
@@ -10133,6 +10522,16 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
     "node_modules/node-gyp": {
       "version": "11.5.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.5.0.tgz",
@@ -10411,6 +10810,16 @@
       "integrity": "sha512-k41FwbcLnlgnFh69f4qdUfvDQ+5vaSDnVPFI/y5XuhKRq97EnVVneO9F1ESVCdiVu4fCS2L8usX3mU331hB7pg==",
       "license": "BSD-2-Clause",
       "optional": true
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -10789,6 +11198,19 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pretty-format": {
@@ -12198,6 +12620,19 @@
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "license": "MIT"
     },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://artifact.devsnc.com/repository/npm-all/tmpl/-/tmpl-1.0.5.tgz",
@@ -12543,6 +12978,16 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/unrs-resolver": {
@@ -13039,6 +13484,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -37,9 +37,10 @@
     "lint": "eslint 'src/**/*.ts' --config eslint.config.js",
     "lint:fix": "eslint 'src/**/*.ts' --config eslint.config.js --fix",
     "test": "jest",
-    "validate:snippets": "bash .mosey/scripts/validate-snippets.sh",
-    "validate:specs": "node .mosey/scripts/validate-specs.mjs",
-    "validate:instructs": "node .mosey/scripts/validate-instructs.mjs",
+    "validate:snippets": "bash scripts/validate-snippets.sh",
+    "validate:specs": "node scripts/validate-specs.mjs",
+    "validate:instructs": "node scripts/validate-instructs.mjs",
+    "bundle": "npm run build && node scripts/bundle.mjs",
     "inspect": "npx @modelcontextprotocol/inspector node dist/index.js",
     "inspect:dev": "npx @modelcontextprotocol/inspector ts-node src/index.ts",
     "inspect:published": "npx @modelcontextprotocol/inspector npx @modesty/fluent-mcp"
@@ -61,6 +62,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@anthropic-ai/mcpb": "2.1.2",
     "@eslint/js": "^10.0.1",
     "@rollup/plugin-commonjs": "^29.0.3",
     "@rollup/plugin-json": "^6.1.0",

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -1,0 +1,64 @@
+import { execFileSync } from 'node:child_process';
+import { cp, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const packageJson = JSON.parse(await readFile(path.join(projectRoot, 'package.json'), 'utf8'));
+const outputPath = path.join(projectRoot, `${packageJson.name.replace(/^@[^/]+\//, '')}-${packageJson.version}.mcpb`);
+const stagePath = await mkdtemp(path.join(os.tmpdir(), 'fluent-mcpb-'));
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const require = createRequire(import.meta.url);
+const mcpbPackageRoot = path.resolve(path.dirname(require.resolve('@anthropic-ai/mcpb')), '..');
+const mcpbCli = path.join(mcpbPackageRoot, 'dist', 'cli', 'cli.js');
+
+try {
+  await cp(path.join(projectRoot, 'manifest.json'), path.join(stagePath, 'manifest.json'));
+  await cp(path.join(projectRoot, 'package.json'), path.join(stagePath, 'package.json'));
+  await cp(path.join(projectRoot, 'package-lock.json'), path.join(stagePath, 'package-lock.json'));
+  await cp(path.join(projectRoot, 'dist'), path.join(stagePath, 'dist'), { recursive: true });
+  await cp(path.join(projectRoot, 'res'), path.join(stagePath, 'res'), { recursive: true });
+  await cp(path.join(projectRoot, 'license.txt'), path.join(stagePath, 'license.txt'));
+  const npmUserConfig = path.join(stagePath, '.bundle-npmrc');
+  // shell:true passes argv through cmd.exe; preserve temp paths containing spaces.
+  const npmUserConfigArg = process.platform === 'win32' ? `"${npmUserConfig}"` : npmUserConfig;
+  await writeFile(npmUserConfig, 'registry=https://registry.npmjs.org\n');
+
+  console.log('Installing production dependencies in the bundle staging directory...');
+  execFileSync(npmCommand, [
+    'ci',
+    '--omit=dev',
+    '--ignore-scripts',
+    '--userconfig',
+    npmUserConfigArg,
+    '--no-audit',
+    '--no-fund',
+  ], {
+    cwd: stagePath,
+    // Node 20.12+ rejects launching .cmd files without a shell on Windows.
+    // The command and every argument are fixed by this script, so shell use
+    // is bounded to the npm bootstrap invocation and has no user input.
+    shell: process.platform === 'win32',
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      npm_config_allow_scripts: '',
+      npm_config_ignore_scripts: 'true',
+      npm_config_local_prefix: stagePath,
+      npm_config_userconfig: npmUserConfig,
+    },
+  });
+
+  // This config is only needed for npm ci; do not ship it in the MCPB archive.
+  await rm(npmUserConfig, { force: true });
+
+  console.log(`Packing ${outputPath}...`);
+  execFileSync(process.execPath, [mcpbCli, 'pack', stagePath, outputPath], {
+    cwd: projectRoot,
+    stdio: 'inherit',
+  });
+} finally {
+  await rm(stagePath, { recursive: true, force: true });
+}

--- a/scripts/validate-instructs.mjs
+++ b/scripts/validate-instructs.mjs
@@ -1,0 +1,406 @@
+#!/usr/bin/env node
+/**
+ * validate-instructs.mjs — cross-check every res/instruct/*.md against the
+ * SDK 4.7.1 documentation surface returned by `now-sdk explain`.
+ *
+ * Why: instruct files are prose with backtick-quoted API names, property names,
+ * enum literals, and import paths. They drift silently when the SDK renames or
+ * removes things. This script catches references that no longer appear in any
+ * SDK explain topic.
+ *
+ * Approach:
+ *   1. List all explain topics, fetch each with caching (parallelized).
+ *   2. Concatenate into one corpus blob (the SDK's "known vocabulary").
+ *   3. For each instruct file, extract backtick tokens, classify, and report
+ *      any "validatable" token that doesn't appear anywhere in the corpus.
+ *
+ * Outputs:
+ *   coverage/instruct-validation.md
+ *
+ * Usage:
+ *   npm run validate:instructs                  # validate all
+ *   node scripts/validate-instructs.mjs flow    # filter by basename substring
+ *   node scripts/validate-instructs.mjs --no-cache  # refetch all explain output
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+// This script lives in scripts/. The repo root (res/, node_modules/,
+// coverage/) is one level up; the validator scratch dir lives under .mosey/.
+const PROJECT_ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const MOSEY_ROOT = path.join(PROJECT_ROOT, '.mosey');
+const INSTRUCT_DIR = path.join(PROJECT_ROOT, 'res', 'instruct');
+const WORK_DIR = path.join(MOSEY_ROOT, 'instruct-validation');
+const CACHE_DIR = path.join(WORK_DIR, 'cache');
+const COVERAGE_DIR = path.join(PROJECT_ROOT, 'coverage');
+const REPORT_FILE = path.join(COVERAGE_DIR, 'instruct-validation.md');
+
+const args = process.argv.slice(2);
+const NO_CACHE = args.includes('--no-cache');
+const FILTER = args.find(a => !a.startsWith('--'));
+
+// ─── Whitelist: platform globals + JS runtime that may appear in instructs
+// but are not necessarily in the explain corpus. Anything here is treated
+// as a known identifier regardless of corpus.
+const WHITELIST = new Set([
+    // Fluent platform globals
+    'Now.ID', 'Now.include', 'Now.attach', 'Now.ref', 'Now',
+    'now.config.json', 'keys.ts', 'now.ts',
+    'g_form', 'g_scratchpad', 'g_user', 'g_list', 'g_request',
+    'GlideRecord', 'GlideAjax', 'GlideForm',
+    'gs', 'gs.getProperty', 'gs.eventQueue', 'gs.addInfoMessage', 'gs.log',
+    'gs.info', 'gs.warn', 'gs.error', 'gs.hasRole',
+    'current', 'previous', 'event', 'email', 'logger', 'classifier',
+    'logger.info', 'logger.warn', 'logger.error',
+    // Common script-context objects
+    'params', 'params.trigger', 'params.flowVariables', 'params.inputs',
+    'producer', 'response', 'request',
+    // AngularJS service injections (Service Portal widgets)
+    '$q', '$timeout', '$sce', '$scope', '$http', '$rootScope', '$window', '$location',
+    // Jelly conventions (UI Page)
+    'jvar_', 'jelly_',
+    // Common JS / TS keywords / globals
+    'string', 'number', 'boolean', 'object', 'array', 'any', 'void', 'null', 'undefined',
+    'true', 'false',
+    // Well-known ServiceNow tables / sys_id prefixes (not always echoed verbatim by explain)
+    'sys_id', 'sys_user', 'sys_user_role', 'sys_dictionary', 'sys_dictionary_override',
+    'sys_ui_message', 'sysevent_registry', 'sysverb_save', 'sysverb_custom_action',
+    'sysevent_email_action', 'sys_email_action', 'sys_filter_option_dynamic',
+    'item_option_new', 'item_option_new_set',
+    'sc_cat_item', 'sc_cat_item_producer',
+    'incident', 'task',
+    // Fluent build-time helpers (resolved at compile, not exported in types)
+    'get_sys_id',
+    // ServiceNow business_calendar built-in names
+    'Year', 'Quarter', 'Month', 'Week',
+    // ServicePortal legacy property names that current instructs intentionally
+    // mention as deprecated (replaced by customCss / fields). Whitelist so the
+    // validator doesn't flag the documented "do NOT use" reference.
+    'cssTemplate', 'sassSrc',
+    // Dashboard componentProps suggested keys (free-form Record<string,unknown>;
+    // not enumerable from SDK explain but documented conventions for report widgets)
+    'reportId', 'reportSysId',
+]);
+
+// Prefixes that mark a dotted token as a USER-CHOSEN identifier in an example,
+// not an SDK symbol. Skip these without flagging.
+const EXAMPLE_VAR_PREFIXES = new Set([
+    'myVariableSet', 'myVariable', 'topLayout', 'mySubflow',
+    // AI Agent prompt template variables (documented platform convention)
+    't', 'p',
+    // Workspace expression namespaces (typed proxies, not exported globals)
+    'Workspace', 'UxList',
+]);
+
+// ─── Run a shell command, capture stdout
+function run(cmd, args, options = {}) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(cmd, args, { ...options });
+        let stdout = '', stderr = '';
+        child.stdout?.on('data', d => stdout += d);
+        child.stderr?.on('data', d => stderr += d);
+        child.on('error', reject);
+        child.on('close', code => {
+            if (code !== 0) reject(new Error(`${cmd} exited ${code}: ${stderr}`));
+            else resolve(stdout);
+        });
+    });
+}
+
+// ─── Fetch raw explain output for a topic, with file-level caching
+async function fetchExplain(topic) {
+    const cacheFile = path.join(CACHE_DIR, `${topic}.md`);
+    if (!NO_CACHE && fs.existsSync(cacheFile)) {
+        return fs.readFileSync(cacheFile, 'utf8');
+    }
+    try {
+        const out = await run('npx', ['now-sdk', 'explain', topic, '--format', 'raw'], {
+            cwd: PROJECT_ROOT,
+        });
+        fs.writeFileSync(cacheFile, out);
+        return out;
+    } catch (e) {
+        // Some topics may fail to render; record empty so we don't refetch forever
+        fs.writeFileSync(cacheFile, '');
+        return '';
+    }
+}
+
+// ─── Parallel fetch with concurrency limit
+async function fetchAll(topics, concurrency = 8) {
+    const results = new Map();
+    let i = 0;
+    let lastReported = 0;
+    async function worker() {
+        while (i < topics.length) {
+            const idx = i++;
+            const topic = topics[idx];
+            results.set(topic, await fetchExplain(topic));
+            if (idx - lastReported >= 20 || idx === topics.length - 1) {
+                process.stderr.write(`  fetched ${idx + 1}/${topics.length} topics\n`);
+                lastReported = idx;
+            }
+        }
+    }
+    await Promise.all(Array.from({ length: concurrency }, worker));
+    return results;
+}
+
+// ─── Discover all SDK explain topics
+async function listTopics() {
+    const out = await run('npx', ['now-sdk', 'explain', '--list', '--format', 'raw'], {
+        cwd: PROJECT_ROOT,
+    });
+    const topics = [];
+    for (const line of out.split('\n')) {
+        const m = line.match(/^([a-z][a-z0-9-]+(?:-api|-guide|-overview|-reference))\b/);
+        if (m) topics.push(m[1]);
+    }
+    return topics;
+}
+
+// ─── Extract every backtick-quoted token from a markdown file
+function extractBacktickTokens(content) {
+    const tokens = [];
+    // Match `…` but skip fenced code blocks (we treat them transparently here)
+    const re = /`([^`\n]+)`/g;
+    let m;
+    while ((m = re.exec(content)) !== null) {
+        tokens.push({ raw: m[1], offset: m.index });
+    }
+    return tokens;
+}
+
+// ─── Classify a token; return { kind, normalized } or null to skip
+function classifyToken(raw) {
+    const t = raw.trim();
+    if (!t) return null;
+
+    // Skip multi-statement / long code fragments
+    if (t.length > 100) return null;
+    // Skip tokens with semicolons/braces (code, not identifier)
+    if (/[;{}]/.test(t)) return null;
+    // Skip URLs and code with parens containing more than a simple call signature
+    if (/^https?:\/\//.test(t)) return null;
+    // Skip prose containing English words with spaces
+    if (/\s/.test(t) && !/^'[^']+'$/.test(t)) return null;
+
+    // Skip filename / URL-fragment references: foo.md, foo.ts, foo.js, foo.do, foo.json, foo.css, foo.scss, foo.html
+    if (/\.(md|ts|tsx|js|jsx|do|json|css|scss|html|xml|sql)$/.test(t)) return null;
+
+    // Skip JSON-path-style references in config files (kept as prose)
+    if (/^dependencies\.[a-z_]+\.[a-z_]+$/.test(t)) return null;
+
+    // Single-quoted string literal: 'value' or '...'
+    const sqMatch = t.match(/^'([^']*)'$/);
+    if (sqMatch) {
+        const val = sqMatch[1];
+        // Skip empty strings, long, or non-validatable values
+        if (!val) return null;
+        if (val.length > 60) return null;
+        // Skip values with spaces or punctuation that suggest prose/sentences
+        if (/[\s,]/.test(val)) return null;
+        // Skip placeholder examples like '...'
+        if (val === '...' || val === '…') return null;
+        // Skip strings that are clearly encoded queries or script expressions:
+        //   contain `=`, `^`, `(`, `"`, `\` — not simple enum literals.
+        if (/[=^()"\\]/.test(val)) return null;
+        // Skip encoded-query fragments with embedded operator codes
+        // (e.g. 'assigned_toISNOTEMPTY', 'shortISEMPTY', 'foo_atSTARTSWITH'_)
+        if (/[A-Z]{4,}/.test(val)) return null;
+        // Skip strings that look like dotted table.column refs (e.g. 'parent_table.child_table')
+        if (/^[a-z_]+\.[a-z_]+(?:\.[a-z_]+)*$/.test(val)) return null;
+        // Skip path-style values (TZs, slashes, dashes) - too variable to validate
+        if (/[\/]/.test(val)) return null;
+        // Skip kebab-case slugs (often workspace paths / page IDs / component names)
+        if (/^[a-z][a-z0-9]*(?:-[a-z0-9]+)+$/.test(val)) return null;
+        // Skip short all-uppercase codes (TZ abbreviations: GMT, UTC, EST, etc.)
+        if (/^[A-Z]{2,5}$/.test(val)) return null;
+        return { kind: 'enum-literal', normalized: val };
+    }
+
+    // Import paths
+    if (t.startsWith('@servicenow/')) {
+        return { kind: 'import-path', normalized: t };
+    }
+
+    // Function call notation like `Action()` or `wfa.action()`
+    const callMatch = t.match(/^([A-Za-z_$][\w$.]*)\(\s*\)?$/) || t.match(/^([A-Za-z_$][\w$.]*)\([^)]*\)$/);
+    if (callMatch) {
+        return { kind: 'call', normalized: callMatch[1] };
+    }
+
+    // Dot-walked or namespaced identifier (e.g., wfa.action, action.core.createRecord)
+    if (/^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)+$/.test(t)) {
+        const head = t.split('.')[0];
+        // Skip example-variable dotted paths (e.g. myVariableSet.variables.x, t.input.x)
+        if (EXAMPLE_VAR_PREFIXES.has(head)) return null;
+        return { kind: 'dotted', normalized: t };
+    }
+
+    // Simple identifier (camelCase, PascalCase, snake_case)
+    if (/^[A-Za-z_$][\w$]*$/.test(t)) {
+        return { kind: 'identifier', normalized: t };
+    }
+
+    // Type-style: Record<'sys_user_role'>, (string | Role)[], etc.
+    if (/^[A-Z][\w<>|,\s'.\[\]]*$/.test(t)) {
+        // Skip; type expressions are noisy to validate
+        return null;
+    }
+
+    return null;
+}
+
+// ─── Validate a single token against the corpus
+function isKnown(normalized, kind, corpus) {
+    if (WHITELIST.has(normalized)) return true;
+    // For dotted/call tokens, also try the head and last segment
+    if (kind === 'dotted' || kind === 'call') {
+        const parts = normalized.split('.');
+        const head = parts[0];
+        const tail = parts[parts.length - 1];
+        if (WHITELIST.has(head)) return true;
+        if (corpus.includes(normalized)) return true;
+        if (tail !== normalized && corpus.includes(tail)) return true;
+        return false;
+    }
+    // Case-sensitive corpus check
+    if (corpus.includes(normalized)) return true;
+    // For enum literals, try with surrounding quotes (the corpus has them quoted)
+    if (kind === 'enum-literal') {
+        if (corpus.includes(`'${normalized}'`)) return true;
+        if (corpus.includes(`"${normalized}"`)) return true;
+        return false;
+    }
+    return false;
+}
+
+// ─── Read all SDK .d.ts type definitions as a secondary corpus
+//     (catches enum values explained in types but not surfaced by `explain`)
+function readSdkTypeDefs() {
+    const sdkCoreDist = path.join(PROJECT_ROOT, 'node_modules', '@servicenow', 'sdk-core', 'dist');
+    if (!fs.existsSync(sdkCoreDist)) return '';
+    const buf = [];
+    function walk(dir) {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            const full = path.join(dir, entry.name);
+            if (entry.isDirectory()) walk(full);
+            else if (entry.isFile() && entry.name.endsWith('.d.ts')) {
+                try { buf.push(fs.readFileSync(full, 'utf8')); } catch { /* ignore */ }
+            }
+        }
+    }
+    walk(sdkCoreDist);
+    return buf.join('\n\n');
+}
+
+// ─── Main
+async function main() {
+    fs.mkdirSync(CACHE_DIR, { recursive: true });
+    fs.mkdirSync(COVERAGE_DIR, { recursive: true });
+
+    process.stderr.write('Discovering SDK explain topics...\n');
+    const topics = await listTopics();
+    process.stderr.write(`  ${topics.length} topics found\n`);
+
+    process.stderr.write('Fetching explain output (cached)...\n');
+    const corpusMap = await fetchAll(topics);
+    const explainCorpus = Array.from(corpusMap.values()).join('\n\n');
+    process.stderr.write(`  explain corpus = ${explainCorpus.length} chars\n`);
+
+    process.stderr.write('Loading SDK .d.ts type definitions...\n');
+    const typeCorpus = readSdkTypeDefs();
+    process.stderr.write(`  type corpus = ${typeCorpus.length} chars\n`);
+
+    const corpus = explainCorpus + '\n\n' + typeCorpus;
+
+    const files = fs.readdirSync(INSTRUCT_DIR)
+        .filter(f => f.startsWith('fluent_instruct_') && f.endsWith('.md'))
+        .filter(f => !FILTER || f.includes(FILTER));
+
+    const fileResults = [];
+    let totalIssues = 0;
+
+    for (const file of files) {
+        const content = fs.readFileSync(path.join(INSTRUCT_DIR, file), 'utf8');
+        const tokens = extractBacktickTokens(content);
+        const issues = [];
+        const seen = new Set();
+        for (const { raw, offset } of tokens) {
+            const cls = classifyToken(raw);
+            if (!cls) continue;
+            const key = `${cls.kind}::${cls.normalized}`;
+            if (seen.has(key)) continue;
+            seen.add(key);
+            if (!isKnown(cls.normalized, cls.kind, corpus)) {
+                // Find line number
+                const before = content.slice(0, offset);
+                const line = before.split('\n').length;
+                issues.push({ raw, ...cls, line });
+            }
+        }
+        fileResults.push({ file, total: tokens.length, unique: seen.size, issues });
+        totalIssues += issues.length;
+    }
+
+    // ─── Write report
+    const okFiles = fileResults.filter(r => r.issues.length === 0);
+    const badFiles = fileResults.filter(r => r.issues.length > 0);
+
+    const lines = [];
+    lines.push('# Instruct Validation Report');
+    lines.push('');
+    lines.push(`Validated against \`now-sdk explain\` corpus from **${topics.length}** SDK 4.7.1 topics.`);
+    lines.push('');
+    lines.push(`- **${fileResults.length}** instruct files scanned`);
+    lines.push(`- **${okFiles.length}** clean (all backtick tokens resolved)`);
+    lines.push(`- **${badFiles.length}** with unresolved tokens`);
+    lines.push(`- **${totalIssues}** total unresolved tokens`);
+    lines.push('');
+    if (badFiles.length > 0) {
+        lines.push('## Files with unresolved tokens');
+        lines.push('');
+        for (const r of badFiles) {
+            lines.push(`### ${r.file}  (${r.issues.length} unresolved)`);
+            lines.push('');
+            lines.push('| Line | Token | Kind |');
+            lines.push('|------|-------|------|');
+            for (const iss of r.issues) {
+                const tok = `\`${iss.raw.replace(/\|/g, '\\|')}\``;
+                lines.push(`| ${iss.line} | ${tok} | ${iss.kind} |`);
+            }
+            lines.push('');
+        }
+    }
+    if (okFiles.length > 0) {
+        lines.push('## Clean files');
+        lines.push('');
+        for (const r of okFiles) {
+            lines.push(`- ${r.file} — ${r.unique} unique tokens checked`);
+        }
+        lines.push('');
+    }
+
+    fs.writeFileSync(REPORT_FILE, lines.join('\n'));
+
+    // ─── Console summary
+    console.log('');
+    console.log(`Instruct validation: ${okFiles.length}/${fileResults.length} clean, ${totalIssues} unresolved tokens`);
+    console.log(`Report: ${path.relative(PROJECT_ROOT, REPORT_FILE)}`);
+    if (badFiles.length > 0) {
+        console.log('');
+        console.log('Top unresolved tokens by file:');
+        for (const r of badFiles.slice(0, 10)) {
+            console.log(`  ${r.file} (${r.issues.length}):`);
+            for (const iss of r.issues.slice(0, 5)) {
+                console.log(`    L${iss.line}  [${iss.kind}]  ${iss.raw}`);
+            }
+        }
+    }
+    process.exit(totalIssues === 0 ? 0 : 1);
+}
+
+main().catch(e => { console.error(e); process.exit(2); });

--- a/scripts/validate-snippets.sh
+++ b/scripts/validate-snippets.sh
@@ -1,0 +1,400 @@
+#!/usr/bin/env bash
+#
+# validate-snippets.sh — Validate that all Fluent API snippets compile
+# against the installed @servicenow/sdk via `now-sdk build`.
+#
+# Usage:
+#   bash scripts/validate-snippets.sh              # validate all snippets
+#   bash scripts/validate-snippets.sh ai-agent     # validate only ai-agent snippets
+#   bash scripts/validate-snippets.sh --changed    # validate only git-changed snippets
+#
+set -euo pipefail
+
+# This script lives in scripts/; the repo root (res/, node_modules/,
+# coverage/) is one level up.
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SNIPPET_DIR="$PROJECT_ROOT/res/snippet"
+NODE_MODULES="$PROJECT_ROOT/node_modules"
+WORK_DIR=""
+FILTER="${1:-}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# Counters
+TOTAL=0
+PASSED=0
+FAILED=0
+SKIPPED=0
+EXPECTED_FAIL=0
+
+# Report file (coverage/snippet-validation.md)
+REPORT_FILE="$PROJECT_ROOT/coverage/snippet-validation.md"
+PASS_LIST=()
+FAIL_LIST=()
+XFAIL_LIST=()
+SKIP_LIST=()
+
+# Snippets known to reference external symbols not available in isolation.
+# These are tracked so regressions in *other* snippets are still caught.
+EXPECTED_FAILURES=(
+  # Catalog snippets reference external catalogItemRef / variableSetRef variables
+  "fluent_snippet_catalog-client-script_0001.md"
+  "fluent_snippet_catalog-ui-policy_0001.md"
+  "fluent_snippet_catalog-item_0001.md"
+  "fluent_snippet_catalog-item-record-producer_0001.md"
+  "fluent_snippet_catalog-variable_0001.md"
+  "fluent_snippet_variable-set_0001.md"
+  # Workspace snippet references exported workspace object cross-file
+  "fluent_snippet_dashboard_0001.md"
+  # SLA snippet references external variables
+  "fluent_snippet_sla_0001.md"
+  # NowAssist snippet references external script file and requires full project context
+  "fluent_snippet_now-assist-skill-config_0001.md"
+  # Snippets using get_sys_id() global (not available in isolation)
+  "fluent_snippet_scheduled-script_0005.md"
+  "fluent_snippet_acl_0001.md"
+  "fluent_snippet_acl_0003.md"
+  "fluent_snippet_list_0002.md"
+  # Form snippets using legacy Record API with get_sys_id
+  "fluent_snippet_form_0001.md"
+  "fluent_snippet_form_0003.md"
+  "fluent_snippet_form_0004.md"
+  # Snippets with unused variable warnings (strict mode, not actual errors)
+  "fluent_snippet_application-menu_0001.md"
+  "fluent_snippet_application-menu_0002.md"
+  "fluent_snippet_application-menu_0003.md"
+  "fluent_snippet_application-menu_0004.md"
+  "fluent_snippet_application-menu_0005.md"
+  # Column snippets — scope-dependent naming enforced by build
+  "fluent_snippet_column_0001.md"
+  "fluent_snippet_column_0002.md"
+  "fluent_snippet_column-generic_0001.md"
+  # Cross-scope privilege references external scope
+  # Table snippets — scope prefix naming
+  "fluent_snippet_table_0001.md"
+  "fluent_snippet_table_0002.md"
+  "fluent_snippet_table_0003.md"
+  "fluent_snippet_table_0004.md"
+  # Column 0003-0005 — global scope prefix requirements (pre-existing)
+  "fluent_snippet_column_0003.md"
+  "fluent_snippet_column_0004.md"
+  "fluent_snippet_column_0005.md"
+  # Service-portal snippets — use old API patterns or reference external modules (pre-existing)
+  "fluent_snippet_service-portal_0001.md"
+  "fluent_snippet_service-portal_0002.md"
+  "fluent_snippet_service-portal_0003.md"
+  "fluent_snippet_service-portal_0004.md"
+  "fluent_snippet_service-portal_0005.md"
+  "fluent_snippet_service-portal_0006.md"
+  "fluent_snippet_service-portal_0007.md"
+  "fluent_snippet_service-portal_0008.md"
+  "fluent_snippet_service-portal_0009.md"
+  "fluent_snippet_service-portal_0010.md"
+  "fluent_snippet_service-portal_0011.md"
+  "fluent_snippet_service-portal_0012.md"
+  "fluent_snippet_service-portal_0013.md"
+  "fluent_snippet_service-portal_0014.md"
+  "fluent_snippet_service-portal_0015.md"
+  "fluent_snippet_service-portal_0016.md"
+  "fluent_snippet_service-portal_0017.md"
+  "fluent_snippet_service-portal_0018.md"
+  # Property/Role snippets — pre-existing issues
+  "fluent_snippet_property_0001.md"
+  "fluent_snippet_property_0002.md"
+  "fluent_snippet_property_0003.md"
+  "fluent_snippet_role_0001.md"
+  # Scripted REST — pre-existing issues
+  "fluent_snippet_scripted-rest_0001.md"
+  # UI page/policy snippets — reference external variables (pre-existing)
+  "fluent_snippet_ui-page_0003.md"
+  "fluent_snippet_ui-page_0007.md"
+  "fluent_snippet_ui-page_0010.md"
+  "fluent_snippet_ui-policy_0003.md"
+  # ATF snippets using assertType (pre-existing, not changed in this update)
+  "fluent_snippet_atf-form_0001.md"
+  "fluent_snippet_atf-server_0001.md"
+  "fluent_snippet_atf-server-record_0001.md"
+  "fluent_snippet_atf-server-record_0002.md"
+  "fluent_snippet_atf-catalog-action_0002.md"
+  "fluent_snippet_atf-catalog-action_0003.md"
+  "fluent_snippet_atf-catalog-validation_001.md"
+  "fluent_snippet_atf-catalog-variable_001.md"
+  "fluent_snippet_atf-form-action_0001.md"
+  "fluent_snippet_atf-form-action_0002.md"
+  "fluent_snippet_atf-form-action_0003.md"
+  "fluent_snippet_atf-form-field_0001.md"
+  "fluent_snippet_atf-server-catalog-item_0001.md"
+  "fluent_snippet_atf-server-catalog-item_0002.md"
+  "fluent_snippet_atf-reporting_0001.md"
+  "fluent_snippet_atf-email_0002.md"
+  "fluent_snippet_atf-email_0003.md"
+)
+
+is_expected_failure() {
+  local name="$1"
+  for ef in "${EXPECTED_FAILURES[@]}"; do
+    [[ "$name" == "$ef" ]] && return 0
+  done
+  return 1
+}
+
+# ── Setup skeleton project ──────────────────────────────────────────
+setup_skeleton() {
+  WORK_DIR="$(mktemp -d /tmp/fluent-snippet-validate-XXXXX)"
+
+  mkdir -p "$WORK_DIR/src/fluent"
+
+  configure_scope "global" "global"
+
+  cat > "$WORK_DIR/package.json" << 'JSON'
+{
+  "name": "snippet-test",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@servicenow/sdk": "4.9.0"
+  }
+}
+JSON
+
+  # Symlink node_modules to avoid reinstalling
+  ln -s "$NODE_MODULES" "$WORK_DIR/node_modules"
+}
+
+configure_scope() {
+  local scope="$1"
+  local scope_id="$2"
+
+  cat > "$WORK_DIR/now.config.json" << 'JSON'
+{
+  "scope": "__SCOPE__",
+  "scopeId": "__SCOPE_ID__",
+  "fluentDir": "src/fluent",
+  "clientDir": ""
+}
+JSON
+  sed -i.bak \
+    -e "s/__SCOPE__/$scope/" \
+    -e "s/__SCOPE_ID__/$scope_id/" \
+    "$WORK_DIR/now.config.json"
+  rm -f "$WORK_DIR/now.config.json.bak"
+}
+
+# ── Cleanup ─────────────────────────────────────────────────────────
+cleanup() {
+  if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
+    rm -rf "$WORK_DIR"
+  fi
+}
+trap cleanup EXIT
+
+# ── Extract TypeScript from markdown ────────────────────────────────
+# Extracts all ```typescript ... ``` blocks, concatenated with newlines.
+extract_typescript() {
+  local file="$1"
+  awk '
+    /^```typescript/ { capture=1; next }
+    /^```$/          { if (capture) { capture=0; print "" }; next }
+    capture          { print }
+  ' "$file"
+}
+
+# ── Build a single snippet ──────────────────────────────────────────
+build_snippet() {
+  local snippet_file="$1"
+  local snippet_name
+  snippet_name="$(basename "$snippet_file")"
+
+  # Most snippets are intentionally validated in global scope. The augment
+  # example owns x_acme_* fields, so validate it in the matching named scope;
+  # otherwise the SDK correctly rejects those fields as foreign-owned.
+  case "$snippet_name" in
+    fluent_snippet_table_0005.md)
+      configure_scope "x_acme" "0123456789abcdef0123456789abcdef"
+      ;;
+    *)
+      configure_scope "global" "global"
+      ;;
+  esac
+
+  # Extract code
+  local code
+  code="$(extract_typescript "$snippet_file")"
+
+  # Skip if no typescript block found
+  if [[ -z "$code" ]]; then
+    printf "  ${YELLOW}[SKIP]${NC} %s (no typescript block)\n" "$snippet_name"
+    SKIPPED=$((SKIPPED + 1))
+    SKIP_LIST+=("$snippet_name|no typescript block")
+    return 0
+  fi
+
+  # Write to skeleton
+  rm -f "$WORK_DIR/src/fluent/"*.now.ts
+  echo "$code" > "$WORK_DIR/src/fluent/snippet.now.ts"
+
+  # Build
+  local output
+  local exit_code=0
+  output="$(npx now-sdk build "$WORK_DIR" 2>&1)" || exit_code=$?
+
+  if [[ $exit_code -eq 0 ]]; then
+    printf "  ${GREEN}[PASS]${NC} %s\n" "$snippet_name"
+    PASSED=$((PASSED + 1))
+    PASS_LIST+=("$snippet_name")
+  else
+    if is_expected_failure "$snippet_name"; then
+      printf "  ${YELLOW}[XFAIL]${NC} %s (expected)\n" "$snippet_name"
+      EXPECTED_FAIL=$((EXPECTED_FAIL + 1))
+      XFAIL_LIST+=("$snippet_name")
+    else
+      printf "  ${RED}[FAIL]${NC} %s\n" "$snippet_name"
+      # Print only the ERROR lines, strip ANSI codes
+      local first_err
+      first_err="$(echo "$output" | grep -i "error" | sed 's/\x1b\[[0-9;]*m//g' | head -1)"
+      echo "$output" | grep -i "error" | sed 's/\x1b\[[0-9;]*m//g' | while IFS= read -r line; do
+        printf "         %s\n" "$line"
+      done
+      FAILED=$((FAILED + 1))
+      FAIL_LIST+=("$snippet_name|$first_err")
+    fi
+  fi
+}
+
+# ── Write markdown report ───────────────────────────────────────────
+write_report() {
+  mkdir -p "$(dirname "$REPORT_FILE")"
+  {
+    echo "# Snippet Validation Report"
+    echo ""
+    echo "Generated by \`scripts/validate-snippets.sh\` against \`@servicenow/sdk@4.9.0\` on $(date -u +"%Y-%m-%dT%H:%M:%SZ")."
+    echo ""
+    echo "## Summary"
+    echo ""
+    echo "| Status | Count |"
+    echo "|--------|-------|"
+    echo "| ✅ Passed | $PASSED |"
+    echo "| ❌ Failed (unexpected) | $FAILED |"
+    echo "| 🟡 Expected failures (fragments / external deps) | $EXPECTED_FAIL |"
+    echo "| ⚪ Skipped (no typescript block) | $SKIPPED |"
+    echo "| **Total** | **$TOTAL** |"
+    echo ""
+    if [[ $FAILED -gt 0 ]]; then
+      echo "## Unexpected failures"
+      echo ""
+      for entry in "${FAIL_LIST[@]}"; do
+        local name="${entry%%|*}"
+        local err="${entry#*|}"
+        echo "- **$name** — \`$err\`"
+      done
+      echo ""
+    fi
+    echo "## Passed (${#PASS_LIST[@]})"
+    echo ""
+    for name in "${PASS_LIST[@]}"; do
+      echo "- $name"
+    done
+    echo ""
+    echo "## Expected failures — fragments or external dependencies (${#XFAIL_LIST[@]})"
+    echo ""
+    echo "Snippets in this list are intentional fragments that demonstrate API patterns but cannot compile in isolation (e.g., references to cross-file imports, scope-dependent identifiers, external Now.include() targets). Tracked so regressions in *other* snippets are still caught."
+    echo ""
+    for name in "${XFAIL_LIST[@]}"; do
+      echo "- $name"
+    done
+    echo ""
+    echo "## Skipped (${#SKIP_LIST[@]})"
+    echo ""
+    for entry in "${SKIP_LIST[@]}"; do
+      local name="${entry%%|*}"
+      local reason="${entry#*|}"
+      echo "- $name — $reason"
+    done
+  } > "$REPORT_FILE"
+  printf "${CYAN}Report written: ${REPORT_FILE#$PROJECT_ROOT/}${NC}\n"
+}
+
+# ── Collect snippet files ───────────────────────────────────────────
+collect_snippets() {
+  if [[ "$FILTER" == "--changed" ]]; then
+    # Only git-changed snippets
+    git -C "$PROJECT_ROOT" diff --name-only HEAD -- 'res/snippet/*.md' | while read -r f; do
+      echo "$PROJECT_ROOT/$f"
+    done
+    git -C "$PROJECT_ROOT" diff --cached --name-only -- 'res/snippet/*.md' | while read -r f; do
+      echo "$PROJECT_ROOT/$f"
+    done
+  elif [[ -n "$FILTER" && "$FILTER" != "--"* ]]; then
+    # Filter by metadata type pattern
+    find "$SNIPPET_DIR" -name "fluent_snippet_${FILTER}*.md" -type f | sort
+  else
+    # All snippets
+    find "$SNIPPET_DIR" -name "fluent_snippet_*.md" -type f | sort
+  fi
+}
+
+# ── Main ────────────────────────────────────────────────────────────
+main() {
+  echo ""
+  printf "${BOLD}Validating snippets against now-sdk v4.9.0 build...${NC}\n"
+  echo ""
+
+  # Verify SDK is available
+  if [[ ! -d "$NODE_MODULES/@servicenow/sdk" ]]; then
+    echo "ERROR: @servicenow/sdk not found in node_modules" >&2
+    exit 1
+  fi
+
+  setup_skeleton
+
+  local snippets
+  snippets="$(collect_snippets)"
+
+  if [[ -z "$snippets" ]]; then
+    echo "No snippets found matching filter: ${FILTER:-all}"
+    exit 0
+  fi
+
+  while IFS= read -r snippet_file; do
+    [[ -z "$snippet_file" ]] && continue
+    [[ ! -f "$snippet_file" ]] && continue
+    TOTAL=$((TOTAL + 1))
+    build_snippet "$snippet_file"
+  done <<< "$snippets"
+
+  # Summary
+  echo ""
+  printf "${BOLD}Results:${NC} "
+  printf "${GREEN}%d passed${NC}, " "$PASSED"
+  if [[ $FAILED -gt 0 ]]; then
+    printf "${RED}%d failed${NC}, " "$FAILED"
+  else
+    printf "0 failed, "
+  fi
+  printf "${YELLOW}%d expected failures${NC}, " "$EXPECTED_FAIL"
+  printf "%d skipped, " "$SKIPPED"
+  printf "%d total\n" "$TOTAL"
+  echo ""
+
+  # Write markdown report (only when running over all snippets)
+  if [[ -z "$FILTER" || "$FILTER" == "--changed" ]]; then
+    write_report
+  fi
+
+  # Exit with failure only for unexpected failures
+  if [[ $FAILED -gt 0 ]]; then
+    printf "${RED}Unexpected compilation failures detected!${NC}\n"
+    exit 1
+  fi
+
+  printf "${GREEN}All snippets compile successfully.${NC}\n"
+  exit 0
+}
+
+main

--- a/scripts/validate-specs.mjs
+++ b/scripts/validate-specs.mjs
@@ -1,0 +1,337 @@
+#!/usr/bin/env node
+/**
+ * validate-specs.mjs — TypeScript-type-check every res/spec/*.md against the
+ * locally installed @servicenow/sdk types.
+ *
+ * Catches API rot in the spec docs: removed/renamed symbols, wrong import
+ * paths, unknown property names on closed config types.
+ *
+ * Usage:
+ *   npm run validate:specs            # validate all specs
+ *   node scripts/validate-specs.mjs business-rule  # validate one type
+ *
+ * Outputs:
+ *   coverage/spec-validation.md       # markdown summary
+ *
+ * Approach:
+ *   - Scaffold a .mosey/spec-validation/ project with tsconfig.json + globals.d.ts
+ *   - Symlink node_modules to the project root (contains @servicenow/sdk (installed version))
+ *   - Extract typescript code blocks from each spec, normalize the
+ *     `}): ReturnType` documentation convention into valid TS (`)`).
+ *   - Run `tsc --noEmit` once over the whole tree.
+ *   - Parse per-file errors and write a markdown report.
+ *
+ * Tsconfig is intentionally lenient (strict: false, noImplicitAny: false) so
+ * placeholder values in specs (`$id: ''`, `table: ''`) don't drown the signal.
+ * What we DO catch: object-literal freshness violations (unknown property
+ * names) and module-resolution failures (renamed/removed APIs).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+// This script lives in scripts/. The repo root (res/, node_modules/,
+// coverage/) is one level up; the validator scaffold lives under .mosey/.
+const PROJECT_ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const MOSEY_ROOT = path.join(PROJECT_ROOT, '.mosey');
+const SPEC_DIR = path.join(PROJECT_ROOT, 'res', 'spec');
+const WORK_DIR = path.join(MOSEY_ROOT, 'spec-validation');
+const COVERAGE_DIR = path.join(PROJECT_ROOT, 'coverage');
+const REPORT_FILE = path.join(COVERAGE_DIR, 'spec-validation.md');
+
+const FILTER = process.argv[2];
+
+function setupScaffold() {
+  if (fs.existsSync(WORK_DIR)) fs.rmSync(WORK_DIR, { recursive: true, force: true });
+  fs.mkdirSync(path.join(WORK_DIR, 'src'), { recursive: true });
+
+  // Symlink node_modules to project root (where @servicenow/sdk (installed version) lives)
+  fs.symlinkSync(
+    path.join(PROJECT_ROOT, 'node_modules'),
+    path.join(WORK_DIR, 'node_modules')
+  );
+
+  // Minimal package.json so `npx tsc` resolves from the symlinked node_modules.
+  fs.writeFileSync(
+    path.join(WORK_DIR, 'package.json'),
+    JSON.stringify({ name: 'spec-validation', private: true, version: '0.0.0' })
+  );
+
+  fs.writeFileSync(
+    path.join(WORK_DIR, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        target: 'ES2022',
+        module: 'ESNext',
+        moduleResolution: 'bundler',
+        strict: false,
+        noImplicitAny: false,
+        esModuleInterop: true,
+        skipLibCheck: true,
+        noEmit: true,
+        allowSyntheticDefaultImports: true,
+        resolveJsonModule: true,
+        lib: ['ES2022'],
+        types: [],
+      },
+      include: ['globals.d.ts', 'src/**/*.ts'],
+    }, null, 2)
+  );
+
+  // Fluent globals — injected by the Fluent build, plus all SDK API names so
+  // spec docs (which omit imports) type-check. Loose `any` typing on purpose —
+  // we're validating spec STRUCTURE, not values. Names left UNDECLARED here
+  // (e.g. `catalogItemRef`, `workspaceObject`) are placeholder-variable bugs
+  // that the validator will catch.
+  const fluentGlobals = [
+    // Fluent runtime
+    'Now', 'TemplateValue', 'Duration', 'Time', 'default_view', 'get_sys_id',
+    'get_column_name', 'wfa', 'trigger', 'action', 'actionStep', '_params', 'params',
+    // SDK API surface (top-level constructors and namespaces)
+    'Acl', 'AiAgent', 'AiAgenticWorkflow', 'Alias', 'AliasTemplate',
+    'ApplicationMenu', 'BusinessRule',
+    'ClientScript', 'CrossScopePrivilege', 'DataLookup', 'DataPolicy', 'Documentation',
+    'ImportSet', 'LicensingConfig', 'List', 'NowAssistSkillConfig', 'Property',
+    'RestApi', 'RestMessage', 'RetryPolicy',
+    'Role', 'Test', 'UiPolicy', 'UserPreference', 'atf', 'Record',
+    // Flow / automation surface (also exported from '@servicenow/sdk/automation')
+    'Flow', 'FlowStage', 'Subflow', 'Table',
+    'PlaybookDefinition', 'PlaybookTriggerTypes', 'ActivityDefinitions',
+    // Instance Scan check types
+    'LinterCheck', 'ScriptOnlyCheck', 'ColumnTypeCheck', 'TableCheck',
+    // Service Portal types
+    'SPMenu', 'SPPage', 'SPTheme', 'SPWidget', 'SPWidgetDependency',
+    // Spec-doc placeholder variable names (used in specs to indicate "imagine
+    // a reference variable here"). Real code would substitute real values.
+    'catalogItemRef', 'variableSetRef', 'variableSetObject',
+    'workspaceObject', 'applicabilityObject', 'listConfigObject', 'dataPill',
+    'flowVarSchema',
+    // Column types
+    'ApprovalRulesColumn', 'BasicDateTimeColumn', 'BasicImageColumn',
+    'BooleanColumn', 'CalendarDateTime', 'ChoiceColumn', 'ConditionsColumn',
+    'DateColumn', 'DateTimeColumn', 'DecimalColumn', 'DocumentIdColumn',
+    'DomainIdColumn', 'DomainPathColumn', 'DueDateColumn', 'DurationColumn',
+    'EmailColumn', 'FieldListColumn', 'FieldNameColumn', 'FloatColumn',
+    'GenericColumn', 'GuidColumn', 'HtmlColumn', 'IntegerColumn',
+    'IntegerDateColumn', 'JsonColumn', 'ListColumn', 'MultiLineTextColumn',
+    'NameValuePairsColumn', 'OtherDateColumn', 'Password2Column', 'RadioColumn',
+    'ReferenceColumn', 'ScheduleDateTimeColumn', 'ScriptColumn',
+    'SlushBucketColumn', 'StringColumn', 'SystemClassNameColumn',
+    'TableNameColumn', 'TemplateValueColumn', 'TimeColumn',
+    'TranslatedFieldColumn', 'TranslatedTextColumn', 'UrlColumn',
+    'UserRolesColumn', 'VersionColumn',
+  ];
+  fs.writeFileSync(
+    path.join(WORK_DIR, 'globals.d.ts'),
+    `// Generated by validate-specs.mjs — Fluent runtime globals + SDK API surface.
+// Loose-typed; we're validating spec structure, not value types.
+${fluentGlobals.filter(n => n !== 'TemplateValue').map(name => `declare const ${name}: any;`).join('\n')}
+
+// TemplateValue accepts an optional generic table-name type argument for IntelliSense.
+declare function TemplateValue<_T = any>(config: any): any;
+
+// Now is also referenced in type position (e.g. Now.ID['x'] inside a type alias).
+// Declare a namespace alongside the const so both value and type uses resolve.
+declare namespace Now {
+  export type ID = any;
+}
+`
+  );
+}
+
+function extractTypescript(filePath) {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  // Collect all ```typescript or ```ts blocks, joined with blank lines.
+  const matches = [...content.matchAll(/```(?:typescript|ts)\n([\s\S]+?)\n```/g)];
+  return matches.map(m => m[1]).join('\n\n');
+}
+
+/**
+ * Normalize spec-doc conventions that aren't valid TS:
+ *   - `}): ReturnType[;,]?`                                          → `})[;,]?`
+ *   - `prop?: value` (optional-marker in object literal)             → `prop: value`
+ *   - Bare top-level `{ ... }` blocks (doc convention showing inline configs) wrapped in `void ()` so TS parses as expression
+ */
+function normalizeSpecCode(code) {
+  let s = code;
+
+  // 1. Strip return-type annotations: ")" followed by ":" then either:
+  //    (a) a TypeName like `BusinessRule`, `Promise<X>`, `void`, etc.
+  //    (b) an inline type-object `{ ... }` (possibly multi-line; assumes no nested braces).
+  //    Anchored by lookahead for `;` / `,` / `//` / end of line.
+  s = s.replace(
+    /\)(\s*):\s*(?:[A-Za-z_][\w<>|&,'"`.\[\]\s]*?|\{[^{}]*\})(?=\s*(?:[;,]|\/\/|$))/gm,
+    ')$1'
+  );
+
+  // 2. Strip optional-marker `?:` on object-literal-style property lines
+  //    Matches: leading whitespace + identifier + `?:` + space (only at line start)
+  s = s.replace(/^(\s+[A-Za-z_]\w*)\?:\s/gm, '$1: ');
+
+  return s;
+}
+
+function processSpecs() {
+  let files = fs.readdirSync(SPEC_DIR).filter(
+    f => f.startsWith('fluent_spec_') && f.endsWith('.md')
+  );
+  if (FILTER) {
+    files = files.filter(f => f.includes(FILTER));
+  }
+  const specs = [];
+  for (const filename of files) {
+    const type = filename.replace(/^fluent_spec_/, '').replace(/\.md$/, '');
+    const raw = extractTypescript(path.join(SPEC_DIR, filename));
+    if (!raw) {
+      specs.push({ filename, type, status: 'skipped', reason: 'no typescript block' });
+      continue;
+    }
+    const normalized = normalizeSpecCode(raw);
+    fs.writeFileSync(path.join(WORK_DIR, 'src', `${type}.ts`), normalized);
+    specs.push({ filename, type, status: 'queued' });
+  }
+  return specs;
+}
+
+function runTypecheck() {
+  try {
+    execSync('npx tsc --noEmit -p .', {
+      cwd: WORK_DIR,
+      encoding: 'utf-8',
+      timeout: 5 * 60 * 1000,
+    });
+    return { stdout: '', success: true };
+  } catch (err) {
+    return {
+      stdout: (err.stdout?.toString() || '') + (err.stderr?.toString() || ''),
+      success: false,
+    };
+  }
+}
+
+function parseErrors(output) {
+  const errors = {};
+  for (const line of output.split('\n')) {
+    // Match: src/<file>.ts(line,col): error TSxxxx: <message>
+    const m = line.match(/^src\/(.+?)\.ts\((\d+),(\d+)\):\s*(error TS\d+:.*)$/);
+    if (m) {
+      const [, file, ln, col, msg] = m;
+      if (!errors[file]) errors[file] = [];
+      errors[file].push({ line: parseInt(ln, 10), col: parseInt(col, 10), msg });
+    }
+  }
+  return errors;
+}
+
+function writeReport(specs, errorsByFile) {
+  fs.mkdirSync(COVERAGE_DIR, { recursive: true });
+  const totals = { passed: 0, failed: 0, skipped: 0 };
+  const passList = [];
+  const failList = [];
+  const skipList = [];
+
+  for (const s of specs) {
+    if (s.status === 'skipped') {
+      totals.skipped++;
+      skipList.push(s);
+      continue;
+    }
+    const errs = errorsByFile[s.type] || [];
+    if (errs.length === 0) {
+      totals.passed++;
+      passList.push(s);
+    } else {
+      totals.failed++;
+      failList.push({ ...s, errors: errs });
+    }
+  }
+
+  const lines = [];
+  lines.push('# Spec Type-Check Report');
+  lines.push('');
+  lines.push(`Generated by \`scripts/validate-specs.mjs\` against \`@servicenow/sdk (installed version)\` types on ${new Date().toISOString()}.`);
+  lines.push('');
+  lines.push('## Summary');
+  lines.push('');
+  lines.push('| Status | Count |');
+  lines.push('|--------|-------|');
+  lines.push(`| ✅ Type-checked clean | ${totals.passed} |`);
+  lines.push(`| ❌ Type errors | ${totals.failed} |`);
+  lines.push(`| ⚪ Skipped (no typescript block) | ${totals.skipped} |`);
+  lines.push(`| **Total** | **${specs.length}** |`);
+  lines.push('');
+
+  if (failList.length > 0) {
+    lines.push('## Type errors');
+    lines.push('');
+    for (const f of failList) {
+      lines.push(`### \`${f.filename}\` (${f.errors.length})`);
+      lines.push('');
+      for (const e of f.errors.slice(0, 10)) {
+        lines.push(`- L${e.line}:${e.col} — \`${e.msg}\``);
+      }
+      if (f.errors.length > 10) {
+        lines.push(`- … (${f.errors.length - 10} more)`);
+      }
+      lines.push('');
+    }
+  }
+
+  lines.push(`## Clean (${passList.length})`);
+  lines.push('');
+  for (const s of passList) lines.push(`- ${s.filename}`);
+  lines.push('');
+
+  if (skipList.length > 0) {
+    lines.push(`## Skipped (${skipList.length})`);
+    lines.push('');
+    for (const s of skipList) lines.push(`- ${s.filename} — ${s.reason}`);
+    lines.push('');
+  }
+
+  fs.writeFileSync(REPORT_FILE, lines.join('\n'));
+  return totals;
+}
+
+function main() {
+  console.log(`\nValidating res/spec/*.md against @servicenow/sdk (installed version) types…\n`);
+
+  setupScaffold();
+  const specs = processSpecs();
+  if (specs.length === 0) {
+    console.log('No specs found.');
+    process.exit(0);
+  }
+
+  const result = runTypecheck();
+  const errors = parseErrors(result.stdout);
+
+  // Pretty per-file output to stdout
+  for (const s of specs) {
+    if (s.status === 'skipped') {
+      console.log(`  [SKIP] ${s.filename} (${s.reason})`);
+      continue;
+    }
+    const errs = errors[s.type] || [];
+    if (errs.length === 0) {
+      console.log(`  [OK]   ${s.filename}`);
+    } else {
+      console.log(`  [FAIL] ${s.filename}  (${errs.length} error${errs.length === 1 ? '' : 's'})`);
+      for (const e of errs.slice(0, 3)) {
+        console.log(`         L${e.line}:${e.col} ${e.msg}`);
+      }
+      if (errs.length > 3) console.log(`         … (${errs.length - 3} more)`);
+    }
+  }
+
+  const totals = writeReport(specs, errors);
+  console.log('');
+  console.log(`Results: ${totals.passed} clean, ${totals.failed} with errors, ${totals.skipped} skipped, ${specs.length} total`);
+  console.log(`Report:  coverage/spec-validation.md`);
+  console.log('');
+
+  process.exit(totals.failed > 0 ? 1 : 0);
+}
+
+main();

--- a/test/fixtures/hanging-sdk-cli.js
+++ b/test/fixtures/hanging-sdk-cli.js
@@ -1,0 +1,9 @@
+import { writeFileSync } from 'node:fs';
+
+const pidPath = process.argv[2];
+if (!pidPath) {
+  throw new Error('The hanging SDK CLI fixture requires a pid-file path.');
+}
+
+writeFileSync(pidPath, `${process.pid}\n`);
+setInterval(() => {}, 1_000);

--- a/test/server/wireProtocol.test.ts
+++ b/test/server/wireProtocol.test.ts
@@ -12,8 +12,17 @@
  * `ServeStdioOptions.transport` is the SDK's own "bring your own transport"
  * affordance, so nothing here is a test-only code path in the server.
  */
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { InMemoryTransport } from '@modelcontextprotocol/server';
 import { FluentMcpServer } from '../../src/server/fluentMCPServer.js';
+import { resolveSdkCli } from '../../src/utils/sdkCli.js';
+
+jest.mock('../../src/utils/sdkCli.js', () => ({
+  resolveSdkCli: jest.fn(),
+  resetSdkCliCache: jest.fn(),
+}));
 
 jest.mock('../../src/utils/logger.js', () => require('../mocks/index.js').createLoggerMock());
 
@@ -46,8 +55,10 @@ const LEGACY_VERSION = '2025-11-25';
 const PROTOCOL_VERSION_KEY = 'io.modelcontextprotocol/protocolVersion';
 const CLIENT_CAPABILITIES_KEY = 'io.modelcontextprotocol/clientCapabilities';
 const CLIENT_INFO_KEY = 'io.modelcontextprotocol/clientInfo';
+const HANGING_SDK_CLI = path.resolve(process.cwd(), 'test/fixtures/hanging-sdk-cli.js');
 
 type Frame = Record<string, any>;
+type PendingRequest = { requestId: number; response: Promise<Frame> };
 
 /** Drives one end of a linked transport pair with raw JSON-RPC. */
 class WireClient {
@@ -70,17 +81,24 @@ class WireClient {
   async modern(method: string, params: Record<string, unknown> = {}): Promise<Frame> {
     return this.request(method, {
       ...params,
-      _meta: {
-        [PROTOCOL_VERSION_KEY]: MODERN_VERSION,
-        [CLIENT_CAPABILITIES_KEY]: {},
-        [CLIENT_INFO_KEY]: { name: 'wire-test', version: '1.0.0' },
-      },
+      _meta: this.modernMeta(),
     });
+  }
+
+  async modernPending(method: string, params: Record<string, unknown> = {}, timeoutMs = 10_000): Promise<PendingRequest> {
+    return this.requestPending(method, {
+      ...params,
+      _meta: this.modernMeta(),
+    }, timeoutMs);
   }
 
   /** Sends a plain 2025-era request (no envelope). */
   async legacy(method: string, params: Record<string, unknown> = {}): Promise<Frame> {
     return this.request(method, params);
+  }
+
+  async legacyPending(method: string, params: Record<string, unknown> = {}, timeoutMs = 10_000): Promise<PendingRequest> {
+    return this.requestPending(method, params, timeoutMs);
   }
 
   async legacyInitialize(): Promise<Frame> {
@@ -95,10 +113,28 @@ class WireClient {
     await this.client.send({ jsonrpc: '2.0', method, ...(params && { params }) } as never);
   }
 
+  async modernNotify(method: string, params: Record<string, unknown> = {}): Promise<void> {
+    await this.notify(method, { ...params, _meta: this.modernMeta() });
+  }
+
   private async request(method: string, params: Record<string, unknown>): Promise<Frame> {
+    const pending = await this.requestPending(method, params);
+    return pending.response;
+  }
+
+  private async requestPending(method: string, params: Record<string, unknown>, timeoutMs = 10_000): Promise<PendingRequest> {
     const id = this.nextId++;
+    const response = this.await(id, timeoutMs);
     await this.client.send({ jsonrpc: '2.0', id, method, params } as never);
-    return await this.await(id);
+    return { requestId: id, response };
+  }
+
+  private modernMeta(): Record<string, unknown> {
+    return {
+      [PROTOCOL_VERSION_KEY]: MODERN_VERSION,
+      [CLIENT_CAPABILITIES_KEY]: {},
+      [CLIENT_INFO_KEY]: { name: 'wire-test', version: '1.0.0' },
+    };
   }
 
   private async await(id: number, timeoutMs = 10_000): Promise<Frame> {
@@ -119,6 +155,42 @@ class WireClient {
   async close(): Promise<void> {
     await this.server.stop();
   }
+}
+
+async function waitForPidFile(pidPath: string, timeoutMs = 5_000): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const pid = Number.parseInt((await readFile(pidPath, 'utf8')).trim(), 10);
+      if (Number.isInteger(pid) && pid > 0) {
+        return pid;
+      }
+    } catch {
+      // The fixture has not started yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  throw new Error(`Timed out waiting for hanging SDK CLI pid file: ${pidPath}`);
+}
+
+async function waitForProcessExit(pid: number, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ESRCH') {
+        return;
+      }
+      throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  throw new Error(`Timed out waiting for hanging SDK CLI process ${pid} to exit`);
 }
 
 describe('dual-era wire protocol', () => {
@@ -371,4 +443,75 @@ describe('dual-era wire protocol', () => {
       expect(wire.serverInitiatedRequests()).toEqual([]);
     });
   });
+});
+
+describe('wire-level cancellation at the process boundary (W13)', () => {
+  let wire: WireClient;
+
+  beforeEach(async () => {
+    wire = await WireClient.connect();
+  });
+
+  afterEach(async () => {
+    await wire?.close();
+  });
+
+  it.each([
+    ['2026-07-28', true],
+    ['2025-11-25', false],
+  ])('cancels a live tools/call through the child process for the %s era', async (_era, modern) => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'fluent-mcp-cancel-'));
+    const pidPath = path.join(tempDir, 'child.pid');
+    let childPid: number | undefined;
+
+    const sdkCliMock = resolveSdkCli as jest.MockedFunction<typeof resolveSdkCli>;
+    sdkCliMock.mockReturnValue({ command: process.execPath, baseArgs: [HANGING_SDK_CLI, pidPath] });
+
+    try {
+      if (!modern) {
+        await wire.legacyInitialize();
+        await wire.notify('notifications/initialized');
+      }
+
+      const pending = modern
+        ? await wire.modernPending('tools/call', {
+          name: 'sdk_info',
+          arguments: { flag: '-v' },
+        }, 1_000)
+        : await wire.legacyPending('tools/call', {
+          name: 'sdk_info',
+          arguments: { flag: '-v' },
+        }, 1_000);
+      const cancelledResponse = pending.response.catch(() => undefined);
+
+      childPid = await waitForPidFile(pidPath);
+
+      if (modern) {
+        await wire.modernNotify('notifications/cancelled', { requestId: pending.requestId });
+      } else {
+        await wire.notify('notifications/cancelled', { requestId: pending.requestId });
+      }
+
+      await waitForProcessExit(childPid);
+
+      // sdk@2.0.0 aborts a cancelled request and intentionally suppresses its
+      // response. The existing process-runner robustness test proves the
+      // underlying result is exit 130 with the cancellation/SIGKILL text;
+      // this wire test proves the cancellation reaches that process boundary.
+      expect(await cancelledResponse).toBeUndefined();
+      expect(wire.received.some((message) => message.id === pending.requestId)).toBe(false);
+    } finally {
+      if (childPid !== undefined) {
+        try {
+          process.kill(childPid, 'SIGKILL');
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ESRCH') {
+            throw error;
+          }
+        }
+      }
+      sdkCliMock.mockReset();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  }, 20_000);
 });


### PR DESCRIPTION
…a cancellation proof, and cross-platform tooling hardening.

  - W10 — MCPB packaging - Added MCPB manifest for all 15 tools and user config. - Added npm run bundle with production-only dependency staging. - Added clean-path bundle smoke verification. - Fixed Windows .cmd execution, Windows path quoting, JSON loading, and temporary config cleanup. - Made artifact naming version-generic.

  - W11 — Documentation and lessons
      - Updated README, AGENTS, and GEMINI guidance.
      - Documented required workingDirectory, non-interactive init, no Roots/Sampling/Elicitation, stderr logging, and MCPB setup.

      - Recorded migration lessons and verification evidence.

  - W13 — Wire cancellation - Added a hanging SDK CLI fixture. - Added cancellation tests for both 2026-07-28 and 2025-11-25 protocol eras. - Verified cancellation kills the child process and emits no canceled-request response, matching SDK behavior.

      - Preserved exit-130/SIGKILL assertions in process-runner tests.

  - Tooling follow-up - Moved validators and bundling scripts from .mosey to root scripts/. - Updated npm commands, documentation, historical guidance, and .claude skill references. - Kept validator scratch/cache output under local .mosey/.

  - Verification
      - 39 Jest suites / 494 tests passed.
      - Build, lint, TypeScript, resource validators, MCPB validation, archive integrity, and clean bundle smoke passed.